### PR TITLE
General Improvements 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,17 @@ GitHub Actions and Vercel run on **Linux**; local dev is usually **macOS**. Tool
 1. Check for `Missing: … from lock file` (especially `@esbuild/linux-x64`, `esbuild@0.28.0` under vitest)—lockfile likely pruned on macOS; resync on Node 22.12+ with npm ≥ 11.3, do not add `.npmrc`.
 2. Check for `Cannot find native binding` / missing `@oxc-parser/binding-linux-x64-gnu`—confirm optional deps and npm version; see **`docs/ci-native-deps.md`**.
 3. Check for `husky: not found`—confirm `HUSKY=0` and the `prepare` skip in `package.json`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in this repo’s GitHub Issues via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical roles map 1:1 to GitHub labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,75 @@
+# Neblir
+
+Tabletop RPG companion for characters, inventory, and in-play health and combat state.
+
+## Language
+
+### Character health
+
+**Status**:
+A character’s life state: `ALIVE`, `DECEASED`, or `DERANGED`. Set by game mechanics and also manually editable. A character has one status; `DECEASED` trumps `DERANGED` when both tracks would complete. `DERANGED` does not block death rolls.
+_Avoid_: condition, state (when meaning this enum)
+
+**Stable**:
+Table fiction for a character who is still not `DECEASED` at 0 physical HP after winning death rolls (three successes before three failures). Not a stored status. Further death rolls stay locked until physical HP rises above 0 or someone resets the death-roll track.
+_Avoid_: Stable status, Unconscious status
+
+**Death roll**:
+A check while at 0 physical HP and not `DECEASED` (allowed while `ALIVE` or `DERANGED`): roll a pool of d10s (size = max(Resilience, Stamina) − serious physical injuries, minimum 1); any 8–10 marks one success box, otherwise one failure box. Three failures before three successes → `DECEASED`. Three successes before three failures → not `DECEASED` (stable). Healing above 0 physical HP clears the track. A hit taken while already at 0 physical HP and still in the death-roll cycle marks a failure instead of lowering HP. Death-roll boxes cannot be changed while `DECEASED`.
+_Avoid_: death save (schema may still say `deathSaves`)
+
+**Death-roll reset**:
+Clearing all death-roll success and failure boxes while still at 0 physical HP so a new cycle can begin (e.g. after a hit while stable).
+_Avoid_: revive, stabilize
+
+**Madness roll**:
+The mental mirror of a death roll (Mentality − serious trauma, minimum 1 die; same 8–10 rule). Only while `ALIVE` and at 0 mental HP — not while `DECEASED` or `DERANGED`. Three failures before three successes → `DERANGED` unless the character is already `DECEASED` (then status stays `DECEASED` and the madness track is kept). Three successes → remains not `DERANGED` at 0 mental HP (composed). Healing above 0 mental HP clears the track. A hit taken while already at 0 mental HP and still in the madness-roll cycle marks a failure instead of lowering mental HP. Madness-roll boxes cannot be changed while `DERANGED` or `DECEASED`.
+_Avoid_: sanity check, mental death save
+
+**Composed**:
+Table fiction for a character who is still not `DERANGED` at 0 mental HP after winning madness rolls (three successes before three failures). Not a stored status. Further madness rolls stay locked until mental HP rises above 0 or someone resets the madness-roll track.
+_Avoid_: Composed status, sane
+
+**Madness-roll reset**:
+Clearing all madness-roll success and failure boxes while still at 0 mental HP so a new cycle can begin.
+_Avoid_: restore sanity
+
+**Serious physical injury**:
+A 0–3 counter of major bodily harm. Reduces the death-roll dice pool (one die per injury, minimum one die). At 3, game mechanics set `DECEASED`.
+_Avoid_: major injury (as a separate stored field)
+
+**Serious trauma**:
+A 0–3 counter of major mental harm. Reduces the madness-roll dice pool (one die per trauma, minimum one die). At 3, game mechanics set `DERANGED`.
+_Avoid_: madness counter (the roll track is separate)
+
+### Inventory and vehicles
+
+**Stack quantity**:
+How many of an item a character holds in one inventory entry. Adjustable in place; quantity 0 means the entry is gone.
+_Avoid_: remove (when meaning partial discard), uses (item charge/ammo-of-a-different-kind)
+
+**Nickname**:
+A per-holding display name on an inventory or vehicle row (`customName`). Optional; when empty, the sheet shows the unique override or template name. Editable for every holding, not only unique items or vehicles.
+_Avoid_: custom name (when meaning the unique/template name), name override
+
+**Name override**:
+The unique item or unique vehicle’s own name, stored on the unique record. Edited via **Edit unique item/vehicle**, not via nickname.
+_Avoid_: nickname, custom name (ambiguous)
+
+**Max HP bonus**:
+An extra max HP on a character’s vehicle holding, added to the template or unique max HP. Editable on the character sheet for any owned vehicle.
+_Avoid_: unique max HP, maxHpOverride
+
+**Custom item / custom vehicle**:
+A game-scoped template the GM creates and edits from the GM page. Changing it changes every holding of that template.
+_Avoid_: unique item, unique vehicle
+
+### Paths
+
+**Path**:
+A character may have more than one path (one row per path). Update Character’s single path picker is the **primary path** (highest rank when the form opens). Changing it to a path the character does not have replaces only that primary row; other paths stay. Changing it to a path they already have updates that row in place.
+_Avoid_: class (when meaning this)
+
+**Favourite weapon**:
+The Soldier path’s chosen weapon. Kept whenever a Soldier path row still exists after Update or Level-up.
+_Avoid_: favourite item (when meaning this)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prisma:backfill:special-abilities": "tsx prisma/scripts/backfillCharacterSpecialAbilities.ts",
     "prisma:backfill:enemy-instance-visibility": "tsx prisma/scripts/backfillEnemyInstanceVisibility.ts",
     "prisma:backfill:character-reactions-remaining": "tsx prisma/scripts/backfillCharacterReactionsRemaining.ts",
+    "prisma:backfill:character-madness-saves": "tsx prisma/scripts/backfillCharacterMadnessSaves.ts",
     "data:import:paths-features": "tsx prisma/scripts/upsertPathsAndFeaturesFromFile.ts",
     "data:import:enemies": "tsx prisma/scripts/upsertEnemiesFromFile.ts",
     "data:import:maps": "tsx prisma/scripts/upsertMapsFromFile.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,6 +301,7 @@ type CharacterHealth {
   currentMentalHealth     Int
   currentPhysicalHealth   Int
   deathSaves              CharacterHealthDeathSaves
+  madnessSaves            CharacterHealthMadnessSaves?
   innateMentalHealth      Int
   innatePhysicalHealth    Int
   maxMentalHealth         Int
@@ -313,6 +314,11 @@ type CharacterHealth {
 }
 
 type CharacterHealthDeathSaves {
+  failures  Int
+  successes Int
+}
+
+type CharacterHealthMadnessSaves {
   failures  Int
   successes Int
 }

--- a/prisma/scripts/backfillCharacterMadnessSaves.ts
+++ b/prisma/scripts/backfillCharacterMadnessSaves.ts
@@ -1,0 +1,54 @@
+/**
+ * Sets health.madnessSaves to { successes: 0, failures: 0 } when the field is
+ * missing or null. Optional on the Prisma type so reads already tolerate absence,
+ * but backfilling keeps documents consistent with deathSaves and avoids
+ * write-time surprises when the whole health composite is replaced.
+ * Safe to run multiple times.
+ *
+ * Usage: npx tsx prisma/scripts/backfillCharacterMadnessSaves.ts
+ * Or: npm run prisma:backfill:character-madness-saves
+ *
+ * Env: MONGODB_URI (required; database name comes from the URI path).
+ */
+
+import "dotenv/config";
+import { MongoClient } from "mongodb";
+
+const EMPTY_MADNESS = { successes: 0, failures: 0 };
+
+async function main() {
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) {
+    console.error("MONGODB_URI environment variable is not set");
+    process.exit(1);
+  }
+
+  const client = new MongoClient(mongoUri);
+  await client.connect();
+  const db = client.db();
+
+  const result = await db.collection("Character").updateMany(
+    {
+      $or: [
+        { "health.madnessSaves": { $exists: false } },
+        { "health.madnessSaves": null },
+      ],
+    },
+    {
+      $set: {
+        "health.madnessSaves": EMPTY_MADNESS,
+      },
+    }
+  );
+
+  console.log(
+    `Backfilled madnessSaves: matched ${result.matchedCount}, modified ${result.modifiedCount}.`
+  );
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(pages)/home/characters/[id]/sections/health.tsx
+++ b/src/app/(pages)/home/characters/[id]/sections/health.tsx
@@ -12,6 +12,13 @@ export function getHealthSection(
     gameId?: string | null;
     rollIsPrivate?: boolean;
     mutate?: () => Promise<unknown>;
+    healthWritePending?: boolean;
+    settledCrisisHealth?: {
+      currentPhysicalHealth: number;
+      currentMentalHealth: number;
+      deathSaves: { successes: number; failures: number } | null | undefined;
+      madnessSaves: { successes: number; failures: number } | null | undefined;
+    } | null;
   }
 ): CharacterSectionSlide {
   const health = character.health;
@@ -59,6 +66,8 @@ export function getHealthSection(
           gameId={options?.gameId ?? null}
           rollIsPrivate={options?.rollIsPrivate}
           mutate={options?.mutate ?? (async () => undefined)}
+          healthWritePending={options?.healthWritePending}
+          settledCrisisHealth={options?.settledCrisisHealth}
         />
       </div>
     ),

--- a/src/app/(pages)/home/characters/[id]/sections/health.tsx
+++ b/src/app/(pages)/home/characters/[id]/sections/health.tsx
@@ -1,13 +1,21 @@
 "use client";
 
+import { HealthCrisisPanel } from "@/app/components/character/HealthCrisisPanel";
 import type { CharacterSectionSlide } from "@/app/components/character/CharacterSectionCarousel";
 import type { CharacterDetail } from "@/app/lib/types/character";
 import { KeyValueRow } from "./section-shared";
 
 export function getHealthSection(
-  character: CharacterDetail
+  character: CharacterDetail,
+  options?: {
+    readOnly?: boolean;
+    gameId?: string | null;
+    rollIsPrivate?: boolean;
+    mutate?: () => Promise<unknown>;
+  }
 ): CharacterSectionSlide {
   const health = character.health;
+  const readOnly = options?.readOnly ?? true;
   const entries = [
     {
       label: "Physical",
@@ -22,11 +30,13 @@ export function getHealthSection(
       value: String(health.seriousPhysicalInjuries),
     },
     { label: "Serious Trauma", value: String(health.seriousTrauma) },
-    {
+  ];
+  if (readOnly) {
+    entries.push({
       label: "Status",
       value: String(health.status).replace(/_/g, " ").toLowerCase(),
-    },
-  ];
+    });
+  }
 
   return {
     id: "health",
@@ -43,56 +53,13 @@ export function getHealthSection(
             />
           ))}
         </ul>
-        {health.currentPhysicalHealth === 0 && health.deathSaves && (
-          <div className="border-t border-black pt-4">
-            <span className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-widest text-black">
-              <span className="h-3 w-px bg-black" aria-hidden />
-              Death Rolls
-            </span>
-            <div className="mt-5 flex w-full gap-6">
-              <div className="flex flex-1 flex-col items-center gap-1.5">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-black">
-                  Successes
-                </span>
-                <div className="flex gap-1">
-                  {[0, 1, 2].map((i) => (
-                    <span
-                      key={i}
-                      className="flex h-8 w-8 items-center justify-center rounded border border-black bg-transparent text-sm"
-                      aria-hidden
-                    >
-                      {i < health.deathSaves!.successes ? (
-                        <span className="text-black" aria-label="Success">
-                          ✓
-                        </span>
-                      ) : null}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <div className="flex flex-1 flex-col items-center gap-1.5">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-black">
-                  Failures
-                </span>
-                <div className="flex gap-1">
-                  {[0, 1, 2].map((i) => (
-                    <span
-                      key={i}
-                      className="flex h-8 w-8 items-center justify-center rounded border border-black bg-transparent text-sm"
-                      aria-hidden
-                    >
-                      {i < health.deathSaves!.failures ? (
-                        <span className="text-black" aria-label="Failure">
-                          ✗
-                        </span>
-                      ) : null}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        <HealthCrisisPanel
+          character={character}
+          readOnly={readOnly}
+          gameId={options?.gameId ?? null}
+          rollIsPrivate={options?.rollIsPrivate}
+          mutate={options?.mutate ?? (async () => undefined)}
+        />
       </div>
     ),
   };

--- a/src/app/(pages)/home/characters/[id]/sections/health.tsx
+++ b/src/app/(pages)/home/characters/[id]/sections/health.tsx
@@ -1,14 +1,21 @@
 "use client";
 
+import { CharacterStatusField } from "@/app/components/character/CharacterStatusField";
 import { HealthCrisisPanel } from "@/app/components/character/HealthCrisisPanel";
 import type { CharacterSectionSlide } from "@/app/components/character/CharacterSectionCarousel";
 import type { CharacterDetail } from "@/app/lib/types/character";
 import { KeyValueRow } from "./section-shared";
 
+function emptyTrack() {
+  return { successes: 0, failures: 0 };
+}
+
 export function getHealthSection(
   character: CharacterDetail,
   options?: {
     readOnly?: boolean;
+    /** Owner can still change Status when the sheet is otherwise locked (e.g. deceased). */
+    statusEditable?: boolean;
     gameId?: string | null;
     rollIsPrivate?: boolean;
     mutate?: () => Promise<unknown>;
@@ -23,6 +30,22 @@ export function getHealthSection(
 ): CharacterSectionSlide {
   const health = character.health;
   const readOnly = options?.readOnly ?? true;
+  const statusEditable = options?.statusEditable ?? !readOnly;
+  const mutate = options?.mutate ?? (async () => undefined);
+  const visibilityHealth =
+    options?.healthWritePending && options.settledCrisisHealth != null
+      ? options.settledCrisisHealth
+      : health;
+  const death = visibilityHealth.deathSaves ?? emptyTrack();
+  const madness = visibilityHealth.madnessSaves ?? emptyTrack();
+  const inCrisis =
+    visibilityHealth.currentPhysicalHealth === 0 ||
+    visibilityHealth.currentMentalHealth === 0 ||
+    death.successes > 0 ||
+    death.failures > 0 ||
+    madness.successes > 0 ||
+    madness.failures > 0;
+
   const entries = [
     {
       label: "Physical",
@@ -38,16 +61,13 @@ export function getHealthSection(
     },
     { label: "Serious Trauma", value: String(health.seriousTrauma) },
   ];
-  if (readOnly) {
-    entries.push({
-      label: "Status",
-      value: String(health.status).replace(/_/g, " ").toLowerCase(),
-    });
-  }
 
   return {
     id: "health",
     title: "Health",
+    panelClassName: inCrisis
+      ? "border-neblirWarning-400 bg-paleBlue shadow-[inset_0_0_0_1px_rgba(234,179,8,0.35)]"
+      : undefined,
     children: (
       <div className="space-y-6">
         <ul className="divide-y divide-black">
@@ -59,13 +79,21 @@ export function getHealthSection(
               className="py-3 first:pt-0"
             />
           ))}
+          <CharacterStatusField
+            characterId={character.id}
+            status={health.status}
+            editable={statusEditable}
+            disabled={options?.healthWritePending}
+            mutate={mutate}
+          />
         </ul>
         <HealthCrisisPanel
+          key={character.id}
           character={character}
           readOnly={readOnly}
           gameId={options?.gameId ?? null}
           rollIsPrivate={options?.rollIsPrivate}
-          mutate={options?.mutate ?? (async () => undefined)}
+          mutate={mutate}
           healthWritePending={options?.healthWritePending}
           settledCrisisHealth={options?.settledCrisisHealth}
         />

--- a/src/app/(pages)/home/characters/[id]/update/CharacterUpdateFormContent.tsx
+++ b/src/app/(pages)/home/characters/[id]/update/CharacterUpdateFormContent.tsx
@@ -13,7 +13,13 @@ import type { CharacterUpdateFormValues } from "./schemas";
 import { Button } from "@/app/components/shared/Button";
 import { DangerConfirmModal } from "@/app/components/shared/DangerConfirmModal";
 
-export function CharacterUpdateFormContent() {
+type CharacterUpdateFormContentProps = {
+  pathRankById: Record<string, number>;
+};
+
+export function CharacterUpdateFormContent({
+  pathRankById,
+}: CharacterUpdateFormContentProps) {
   const {
     steps,
     currentStepIndex,
@@ -60,6 +66,7 @@ export function CharacterUpdateFormContent() {
           <PathAndFeaturesStep
             onInitialFeaturesChange={setInitialFeatures}
             initialFeatures={initialFeatures}
+            pathRankById={pathRankById}
           />
         )}
 

--- a/src/app/(pages)/home/characters/[id]/update/page.tsx
+++ b/src/app/(pages)/home/characters/[id]/update/page.tsx
@@ -78,7 +78,11 @@ export default function CharacterUpdatePage() {
         </p>
       </div>
       <FormProvider {...form}>
-        <CharacterUpdateFormContent />
+        <CharacterUpdateFormContent
+          pathRankById={Object.fromEntries(
+            (character.paths ?? []).map((path) => [path.id, path.rank ?? 1])
+          )}
+        />
       </FormProvider>
     </PageSection>
   );

--- a/src/app/(pages)/home/characters/[id]/update/schemas.ts
+++ b/src/app/(pages)/home/characters/[id]/update/schemas.ts
@@ -1,7 +1,7 @@
 import type { CharacterDetail } from "@/app/lib/types/character";
-import type { CharacterCreationRequest } from "@/app/api/characters/schemas";
+import type { CharacterEditableUpdateRequest } from "@/app/api/characters/schemas";
 
-export type CharacterUpdateFormValues = CharacterCreationRequest;
+export type CharacterUpdateFormValues = CharacterEditableUpdateRequest;
 
 export function toCharacterUpdateFormValues(
   character: CharacterDetail
@@ -51,6 +51,7 @@ export function toCharacterUpdateFormValues(
       pathId: selectedPath?.id ?? "",
       rank: selectedPath?.rank ?? character.generalInformation.level ?? 1,
     },
+    primaryPathCharacterId: selectedPath?.pathCharacterId,
     initialFeatures: (character.features ?? []).map((feature) => ({
       featureId: feature.featureId,
       grade: feature.grade,

--- a/src/app/(pages)/home/characters/create/steps/PathAndFeaturesStep.tsx
+++ b/src/app/(pages)/home/characters/create/steps/PathAndFeaturesStep.tsx
@@ -29,11 +29,14 @@ export type InitialFeatureEntry = { featureId: string; grade: number };
 interface PathAndFeaturesStepProps {
   onInitialFeaturesChange?: (features: InitialFeatureEntry[]) => void;
   initialFeatures?: InitialFeatureEntry[];
+  /** When set (character update), rank follows the selected existing path or 1 if new. */
+  pathRankById?: Record<string, number>;
 }
 
 export function PathAndFeaturesStep({
   onInitialFeaturesChange,
   initialFeatures,
+  pathRankById,
 }: PathAndFeaturesStepProps) {
   const { control, watch, setValue, clearErrors, formState } =
     useFormContext<CharacterCreationRequest>();
@@ -52,14 +55,23 @@ export function PathAndFeaturesStep({
     onInitialFeaturesChange?.(selectedFeatures);
   }, [selectedFeatures, onInitialFeaturesChange]);
 
-  useEffect(() => {
-    if (pathId) setValue("path.rank", level);
-  }, [pathId, level, setValue]);
-
   // When we hydrate initial features (refresh), we want to show them once
   // the step mounts. This also keeps the UI synced with controller state.
   const hydratedRef = useRef(false);
   const prevPathIdRef = useRef<string | null | undefined>(undefined);
+  const formRank = watch("path.rank");
+  const derivedRank = !pathId
+    ? formRank
+    : pathRankById
+      ? (pathRankById[pathId] ?? 1)
+      : level;
+  if (
+    pathId &&
+    typeof derivedRank === "number" &&
+    Number(formRank) !== derivedRank
+  ) {
+    setValue("path.rank", derivedRank);
+  }
 
   useEffect(() => {
     // When rehydrating from localStorage, seed the UI with the saved selection.
@@ -215,9 +227,11 @@ export function PathAndFeaturesStep({
   return (
     <div className="space-y-4">
       <p className="text-sm text-black/70">
-        Select a path. Rank is set to your character level. You may choose
-        features using a total of up to <strong>{featureSlots}</strong> grade
-        slots (2 slots per level above 1).
+        {pathRankById
+          ? "Select a path. Rank follows the selected path, or 1 if you pick a path you do not already have."
+          : "Select a path. Rank is set to your character level."}{" "}
+        You may choose features using a total of up to{" "}
+        <strong>{featureSlots}</strong> grade slots (2 slots per level above 1).
       </p>
 
       <div className="mb-6 space-y-3">
@@ -240,7 +254,10 @@ export function PathAndFeaturesStep({
                 disabled={loadingPaths}
                 onChange={(value) => {
                   field.onChange(value);
-                  setValue("path.rank", level);
+                  setValue(
+                    "path.rank",
+                    pathRankById ? (pathRankById[value] ?? 1) : level
+                  );
                   clearErrors("path.pathId");
                 }}
               />

--- a/src/app/api/characters/[id]/health/route.ts
+++ b/src/app/api/characters/[id]/health/route.ts
@@ -1,3 +1,5 @@
+import { applyCharacterHealthPatch } from "@/app/lib/applyCharacterHealthPatch";
+import type { CharacterHealthSnapshot } from "@/app/lib/applyCharacterHealthPatch";
 import { getCharacter, updateCharacter } from "@/app/lib/prisma/character";
 import { NextResponse } from "next/server";
 import { healthUpdateSchema } from "./schema";
@@ -7,6 +9,35 @@ import { logger } from "@/logger";
 import { serializeError } from "../../../shared/errors";
 import { errorResponse } from "../../../shared/responses";
 import { characterBelongsToUser } from "@/app/lib/prisma/characterUser";
+import type { Status } from "@prisma/client";
+
+function toHealthSnapshot(
+  health: CharacterDetailHealth
+): CharacterHealthSnapshot {
+  return {
+    currentPhysicalHealth: health.currentPhysicalHealth,
+    currentMentalHealth: health.currentMentalHealth,
+    maxPhysicalHealth: health.maxPhysicalHealth,
+    maxMentalHealth: health.maxMentalHealth,
+    seriousPhysicalInjuries: health.seriousPhysicalInjuries,
+    seriousTrauma: health.seriousTrauma,
+    deathSaves: health.deathSaves ?? { successes: 0, failures: 0 },
+    madnessSaves: health.madnessSaves ?? { successes: 0, failures: 0 },
+    status: health.status,
+  };
+}
+
+type CharacterDetailHealth = {
+  currentPhysicalHealth: number;
+  currentMentalHealth: number;
+  maxPhysicalHealth: number;
+  maxMentalHealth: number;
+  seriousPhysicalInjuries: number;
+  seriousTrauma: number;
+  deathSaves?: { successes: number; failures: number } | null;
+  madnessSaves?: { successes: number; failures: number } | null;
+  status: Status;
+};
 
 export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
   try {
@@ -68,7 +99,7 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
     }
 
     if (
-      parsedBody.currentPhysicalHealth &&
+      parsedBody.currentPhysicalHealth != null &&
       parsedBody.currentPhysicalHealth >
         existingCharacter.health.maxPhysicalHealth
     ) {
@@ -87,7 +118,7 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
       );
     }
     if (
-      parsedBody.currentMentalHealth &&
+      parsedBody.currentMentalHealth != null &&
       parsedBody.currentMentalHealth > existingCharacter.health.maxMentalHealth
     ) {
       logger.error({
@@ -105,27 +136,32 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
       );
     }
 
-    let newHealth = {
-      ...existingCharacter.health,
-      ...parsedBody,
-    };
-    if (parsedBody.status === "ALIVE") {
-      newHealth = { ...newHealth, status: "ALIVE" };
-    }
-    if (parsedBody.seriousTrauma && parsedBody.seriousTrauma >= 3) {
-      newHealth = { ...newHealth, status: "DERANGED" };
-    }
-    if (
-      (parsedBody.deathSaves?.failures &&
-        parsedBody.deathSaves.failures >= 3) ||
-      (parsedBody.seriousPhysicalInjuries &&
-        parsedBody.seriousPhysicalInjuries >= 3)
-    ) {
-      newHealth = { ...newHealth, status: "DECEASED" };
+    const {
+      deathSaves: patchDeathSaves,
+      madnessSaves: patchMadnessSaves,
+      ...restPatch
+    } = parsedBody;
+    const applied = applyCharacterHealthPatch(
+      toHealthSnapshot(existingCharacter.health),
+      {
+        ...restPatch,
+        ...(patchDeathSaves != null ? { deathSaves: patchDeathSaves } : {}),
+        ...(patchMadnessSaves != null
+          ? { madnessSaves: patchMadnessSaves }
+          : {}),
+      }
+    );
+    if (!applied.ok) {
+      return errorResponse(applied.error, 400);
     }
 
-    const deathSaves = newHealth.deathSaves ?? { successes: 0, failures: 0 };
-    const healthForPrisma = { ...newHealth, deathSaves };
+    const { madnessSaves, ...healthWithoutOptionalMadness } = applied.health;
+    const healthForPrisma = {
+      ...existingCharacter.health,
+      ...healthWithoutOptionalMadness,
+      deathSaves: applied.health.deathSaves,
+      ...(madnessSaves != null ? { madnessSaves } : {}),
+    };
     await updateCharacter(id, {
       health: healthForPrisma,
     });

--- a/src/app/api/characters/[id]/health/schema.ts
+++ b/src/app/api/characters/[id]/health/schema.ts
@@ -1,4 +1,5 @@
 import { healthSchema } from "@/app/lib/types/character";
+import { z } from "zod";
 
 export const healthUpdateSchema = healthSchema
   .pick({
@@ -7,6 +8,11 @@ export const healthUpdateSchema = healthSchema
     seriousPhysicalInjuries: true,
     seriousTrauma: true,
     deathSaves: true,
+    madnessSaves: true,
     status: true,
   })
-  .partial();
+  .partial()
+  .extend({
+    physicalHitsAtZero: z.number().int().min(1).max(3).optional(),
+    mentalHitsAtZero: z.number().int().min(1).max(3).optional(),
+  });

--- a/src/app/api/characters/[id]/inventory/[itemCharacterId]/route.ts
+++ b/src/app/api/characters/[id]/inventory/[itemCharacterId]/route.ts
@@ -1,4 +1,7 @@
-import { ITEM_LOCATION_CARRIED } from "@/app/lib/constants/inventory";
+import {
+  ITEM_LOCATION_CARRIED,
+  MAX_STACK_QUANTITY,
+} from "@/app/lib/constants/inventory";
 import {
   getAutoEquipSlotAdds,
   getEquippedInstanceCount,
@@ -51,6 +54,14 @@ const patchBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("setStatus"),
     status: itemStatusSchema,
+  }),
+  z.object({
+    action: z.literal("setQuantity"),
+    quantity: z.number().int().min(0).max(MAX_STACK_QUANTITY),
+  }),
+  z.object({
+    action: z.literal("setCustomName"),
+    customName: z.string().nullable(),
   }),
 ]);
 
@@ -300,6 +311,39 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
               isEquipped: false,
             }
           : {}),
+      });
+    } else if (action === "setQuantity") {
+      const { quantity } = parsed.data;
+      if (quantity === 0) {
+        await deleteItemCharacter(itemCharacterId);
+        const characterAfterDelete = await getCharacter(id);
+        if (characterAfterDelete?.combatInformation) {
+          const combatUpdate = computeCombatInfoUpdateForCharacter(
+            characterAfterDelete as CharacterForCombatSync
+          );
+          await updateCharacter(id, {
+            combatInformation: {
+              ...characterAfterDelete.combatInformation,
+              ...combatUpdate,
+            },
+          });
+        }
+        return new NextResponse(null, { status: 204 });
+      }
+      const equippedCount = equipSlots.length;
+      await updateItemCharacter(itemCharacterId, {
+        quantity,
+        ...(equippedCount > quantity
+          ? {
+              equipSlots: equipSlots.slice(0, quantity),
+              isEquipped: quantity > 0,
+            }
+          : {}),
+      });
+    } else if (action === "setCustomName") {
+      const trimmed = parsed.data.customName?.trim() ?? "";
+      await updateItemCharacter(itemCharacterId, {
+        customName: trimmed.length > 0 ? trimmed : null,
       });
     } else {
       await updateItemCharacter(itemCharacterId, {

--- a/src/app/api/characters/[id]/route.ts
+++ b/src/app/api/characters/[id]/route.ts
@@ -186,7 +186,22 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
 
     let computed: ReturnType<typeof computeCharacterRequestData>;
     try {
-      computed = computeCharacterRequestData(parseResult.data);
+      computed = computeCharacterRequestData(parseResult.data, false, {
+        preservePlayState: {
+          currentPhysicalHealth: existingCharacter.health.currentPhysicalHealth,
+          currentMentalHealth: existingCharacter.health.currentMentalHealth,
+          deathSaves: existingCharacter.health.deathSaves ?? {
+            successes: 0,
+            failures: 0,
+          },
+          madnessSaves: existingCharacter.health.madnessSaves ?? {
+            successes: 0,
+            failures: 0,
+          },
+          reactionsRemaining:
+            existingCharacter.combatInformation.reactionsRemaining,
+        },
+      });
     } catch (error) {
       if (error instanceof ValidationError) {
         return errorResponse(error.message, 400);
@@ -217,14 +232,30 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
         });
       }
 
-      await tx.pathCharacter.deleteMany({ where: { characterId: id } });
-      await tx.pathCharacter.create({
-        data: {
-          characterId: id,
-          pathId,
-          rank: pathRank,
-        },
-      });
+      const existingPaths = existingCharacter.paths ?? [];
+      const matchingPath = existingPaths.find((path) => path.id === pathId);
+      if (matchingPath?.pathCharacterId) {
+        await tx.pathCharacter.update({
+          where: { id: matchingPath.pathCharacterId },
+          data: { rank: pathRank },
+        });
+      } else {
+        const primaryPath = existingPaths
+          .slice()
+          .sort((a, b) => (b.rank ?? 0) - (a.rank ?? 0))[0];
+        if (primaryPath?.pathCharacterId) {
+          await tx.pathCharacter.delete({
+            where: { id: primaryPath.pathCharacterId },
+          });
+        }
+        await tx.pathCharacter.create({
+          data: {
+            characterId: id,
+            pathId,
+            rank: pathRank,
+          },
+        });
+      }
 
       await tx.featureCharacter.deleteMany({ where: { characterId: id } });
       if (rawInitialFeatures.length > 0) {

--- a/src/app/api/characters/[id]/route.ts
+++ b/src/app/api/characters/[id]/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 import { characterBelongsToUser } from "@/app/lib/prisma/characterUser";
 import { logger } from "@/logger";
-import { characterCreationRequestSchema } from "../schemas";
+import { characterEditableUpdateSchema } from "../schemas";
 import { computeCharacterRequestData } from "../parsing";
 import { getPath } from "@/app/lib/prisma/path";
 import { getAllFeaturesAvailableForPathAndRank } from "@/app/lib/prisma/feature";
@@ -76,8 +76,6 @@ export const GET = auth(async (request: AuthNextRequest, { params }) => {
   }
 });
 
-const characterEditableUpdateSchema = characterCreationRequestSchema;
-
 export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
   try {
     if (!request.auth?.user) {
@@ -136,9 +134,13 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
       );
     }
 
-    const pathId = parseResult.data.path.pathId;
-    const pathRank = parseResult.data.path.rank;
-    const rawInitialFeatures = parseResult.data.initialFeatures ?? [];
+    const {
+      primaryPathCharacterId: primaryPathCharacterIdAtFormOpen,
+      ...updatePayload
+    } = parseResult.data;
+    const pathId = updatePayload.path.pathId;
+    const pathRank = updatePayload.path.rank;
+    const rawInitialFeatures = updatePayload.initialFeatures ?? [];
 
     const path = await getPath(pathId);
     if (!path) {
@@ -186,7 +188,7 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
 
     let computed: ReturnType<typeof computeCharacterRequestData>;
     try {
-      computed = computeCharacterRequestData(parseResult.data, false, {
+      computed = computeCharacterRequestData(updatePayload, false, {
         preservePlayState: {
           currentPhysicalHealth: existingCharacter.health.currentPhysicalHealth,
           currentMentalHealth: existingCharacter.health.currentMentalHealth,
@@ -221,7 +223,7 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
 
     await prisma.$transaction(async (tx) => {
       await tx.characterCurrency.deleteMany({ where: { characterId: id } });
-      const nextWallet = parseResult.data.wallet ?? [];
+      const nextWallet = updatePayload.wallet ?? [];
       if (nextWallet.length > 0) {
         await tx.characterCurrency.createMany({
           data: nextWallet.map((entry) => ({
@@ -240,9 +242,18 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
           data: { rank: pathRank },
         });
       } else {
-        const primaryPath = existingPaths
-          .slice()
-          .sort((a, b) => (b.rank ?? 0) - (a.rank ?? 0))[0];
+        const primaryFromFormOpen =
+          primaryPathCharacterIdAtFormOpen != null
+            ? existingPaths.find(
+                (path) =>
+                  path.pathCharacterId === primaryPathCharacterIdAtFormOpen
+              )
+            : undefined;
+        const primaryPath =
+          primaryFromFormOpen ??
+          existingPaths
+            .slice()
+            .sort((a, b) => (b.rank ?? 0) - (a.rank ?? 0))[0];
         if (primaryPath?.pathCharacterId) {
           await tx.pathCharacter.delete({
             where: { id: primaryPath.pathCharacterId },

--- a/src/app/api/characters/[id]/vehicles/[vehicleCharacterId]/route.ts
+++ b/src/app/api/characters/[id]/vehicles/[vehicleCharacterId]/route.ts
@@ -66,8 +66,10 @@ export const PATCH = auth(async (request: AuthNextRequest, { params }) => {
         currentHp: parsed.data.currentHp,
       });
     } else if (action === "setCustomName") {
-      const customName = parsed.data.customName?.trim() ?? null;
-      await updateVehicleCharacter(vehicleCharacterId, { customName });
+      const trimmed = parsed.data.customName?.trim() ?? "";
+      await updateVehicleCharacter(vehicleCharacterId, {
+        customName: trimmed.length > 0 ? trimmed : null,
+      });
     } else if (action === "setParkedAt") {
       await updateVehicleCharacter(vehicleCharacterId, {
         parkedAt: parsed.data.parkedAt,

--- a/src/app/api/characters/parsing.ts
+++ b/src/app/api/characters/parsing.ts
@@ -41,11 +41,20 @@ function calculateMaxCarryWeight(
   return baseMaxCarryWeight + strengthMod;
 }
 
+export type PreservePlayState = {
+  currentPhysicalHealth: number;
+  currentMentalHealth: number;
+  deathSaves: { successes: number; failures: number };
+  madnessSaves?: { successes: number; failures: number } | null;
+  reactionsRemaining: number;
+};
+
 export function computeCharacterRequestData(
   parsedCharacterCreationRequest:
     | CharacterCreationRequest
     | LevelUpCharacterBody,
-  isLevelUp: boolean = false
+  isLevelUp: boolean = false,
+  options?: { preservePlayState?: PreservePlayState }
 ) {
   const innatePhysicalHealth = Object.values(
     parsedCharacterCreationRequest.innateAttributes.constitution
@@ -170,6 +179,61 @@ export function computeCharacterRequestData(
       ? rawHealth.currentMentalHealth
       : maxMentalHealth;
 
+  const preservePlayState = options?.preservePlayState;
+  const emptyCrisis = { successes: 0, failures: 0 };
+  const deathFromRaw =
+    rawHealth.deathSaves != null &&
+    typeof rawHealth.deathSaves === "object" &&
+    "successes" in (rawHealth.deathSaves as object)
+      ? (rawHealth.deathSaves as { successes: number; failures: number })
+      : emptyCrisis;
+  const madnessFromRaw =
+    rawHealth.madnessSaves != null &&
+    typeof rawHealth.madnessSaves === "object" &&
+    "successes" in (rawHealth.madnessSaves as object)
+      ? (rawHealth.madnessSaves as { successes: number; failures: number })
+      : emptyCrisis;
+
+  const nextPhysical = preservePlayState
+    ? Math.min(preservePlayState.currentPhysicalHealth, maxPhysicalHealth)
+    : isLevelUp
+      ? Math.min(currentPhysicalHealthInput, maxPhysicalHealth)
+      : maxPhysicalHealth;
+  const nextMental = preservePlayState
+    ? Math.min(preservePlayState.currentMentalHealth, maxMentalHealth)
+    : isLevelUp
+      ? Math.min(currentMentalHealthInput, maxMentalHealth)
+      : maxMentalHealth;
+  const nextDeathSaves = preservePlayState
+    ? preservePlayState.deathSaves
+    : isLevelUp
+      ? deathFromRaw
+      : emptyCrisis;
+  const nextMadnessSaves = preservePlayState
+    ? (preservePlayState.madnessSaves ?? emptyCrisis)
+    : isLevelUp
+      ? madnessFromRaw
+      : emptyCrisis;
+  const combatReactionsRemaining =
+    "reactionsRemaining" in
+      (requestWithoutPathAndWallet.combatInformation ?? {}) &&
+    typeof (
+      requestWithoutPathAndWallet.combatInformation as {
+        reactionsRemaining?: number;
+      }
+    ).reactionsRemaining === "number"
+      ? (
+          requestWithoutPathAndWallet.combatInformation as {
+            reactionsRemaining: number;
+          }
+        ).reactionsRemaining
+      : reactionsPerRound;
+  const nextReactionsRemaining = preservePlayState
+    ? Math.min(preservePlayState.reactionsRemaining, reactionsPerRound)
+    : isLevelUp
+      ? Math.min(combatReactionsRemaining, reactionsPerRound)
+      : reactionsPerRound;
+
   return {
     ...requestWithoutPathAndWallet,
     generalInformation: {
@@ -190,18 +254,12 @@ export function computeCharacterRequestData(
       ...requestWithoutPathAndWallet.health,
       innatePhysicalHealth: innatePhysicalHealth,
       maxPhysicalHealth: maxPhysicalHealth,
-      currentPhysicalHealth: isLevelUp
-        ? Math.min(currentPhysicalHealthInput, maxPhysicalHealth)
-        : maxPhysicalHealth,
+      currentPhysicalHealth: nextPhysical,
       innateMentalHealth: innateMentalHealth,
       maxMentalHealth: maxMentalHealth,
-      currentMentalHealth: isLevelUp
-        ? Math.min(currentMentalHealthInput, maxMentalHealth)
-        : maxMentalHealth,
-      deathSaves: {
-        successes: 0,
-        failures: 0,
-      },
+      currentMentalHealth: nextMental,
+      deathSaves: nextDeathSaves,
+      madnessSaves: nextMadnessSaves,
     },
     combatInformation: (() => {
       const armourMod =
@@ -223,7 +281,7 @@ export function computeCharacterRequestData(
           10,
         maxCarryWeight: calculateMaxCarryWeight(parsedCharacterCreationRequest),
         reactionsPerRound: reactionsPerRound,
-        reactionsRemaining: reactionsPerRound,
+        reactionsRemaining: nextReactionsRemaining,
         rangeAttackMod:
           parsedCharacterCreationRequest.innateAttributes.dexterity.manual +
           parsedCharacterCreationRequest.learnedSkills.generalSkills.aim,

--- a/src/app/api/characters/schemas.ts
+++ b/src/app/api/characters/schemas.ts
@@ -86,3 +86,18 @@ export const characterCreationRequestSchema = z
 export type CharacterCreationRequest = z.infer<
   typeof characterCreationRequestSchema
 >;
+
+/**
+ * Update Character body: creation shape plus the PathCharacter id that was
+ * primary (highest rank) when the Update form opened. Used when replacing a
+ * path the character does not already have.
+ */
+export const characterEditableUpdateSchema = characterCreationRequestSchema
+  .extend({
+    primaryPathCharacterId: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type CharacterEditableUpdateRequest = z.infer<
+  typeof characterEditableUpdateSchema
+>;

--- a/src/app/components/character/CharacterDetailView.tsx
+++ b/src/app/components/character/CharacterDetailView.tsx
@@ -65,7 +65,12 @@ export function CharacterDetailView({
     [character]
   ) as KeyedMutator<CharacterDetail | null>;
 
-  const { updateHealth, updateArmour } = useCharacterStatUpdates(
+  const {
+    updateHealth,
+    updateArmour,
+    healthWritePending,
+    settledCrisisHealth,
+  } = useCharacterStatUpdates(
     character.id,
     character,
     mutateAction ?? noopMutate
@@ -202,6 +207,8 @@ export function CharacterDetailView({
         gameId: activeGameId,
         rollIsPrivate: rollPrivacy.defaultPrivateRoll,
         mutate: readOnly ? undefined : mutateAction,
+        healthWritePending: readOnly ? false : healthWritePending,
+        settledCrisisHealth: readOnly ? null : settledCrisisHealth,
       }),
     ];
     const pathsSection = getPathsSection(character, {
@@ -251,6 +258,8 @@ export function CharacterDetailView({
     initiativeGamesLoading,
     activeGameId,
     rollPrivacy,
+    healthWritePending,
+    settledCrisisHealth,
     user?.characterSectionOrder,
   ]);
 

--- a/src/app/components/character/CharacterDetailView.tsx
+++ b/src/app/components/character/CharacterDetailView.tsx
@@ -60,6 +60,11 @@ export function CharacterDetailView({
   mutateAction,
 }: CharacterDetailViewProps) {
   const { user } = useUser();
+  const isDeceased = character.health.status === "DECEASED";
+  /** Owner (or GM) page access — Status + name actions stay available when deceased. */
+  const canManageCharacter = !readOnly;
+  /** Sheet interactions locked for GM view or deceased characters. */
+  const sheetReadOnly = readOnly || isDeceased;
   const noopMutate = useCallback(
     async () => character,
     [character]
@@ -112,7 +117,10 @@ export function CharacterDetailView({
     gameDetails: initiativeGameDetails,
     loading: initiativeGamesLoading,
     refetch: refetchInitiativeGames,
-  } = useCharacterGameDetails(readOnly ? null : character.id, character.games);
+  } = useCharacterGameDetails(
+    sheetReadOnly ? null : character.id,
+    character.games
+  );
 
   const activeGameDetail = useMemo(() => {
     if (!activeGameId) return null;
@@ -126,7 +134,7 @@ export function CharacterDetailView({
 
   const handleDiceSelect = useCallback(
     (item: DiceSelectionItem) => {
-      if (readOnly) return;
+      if (sheetReadOnly) return;
       setSingleAttributeRollSelection(null);
       setDiceSelection((prev) => {
         const idx = prev.findIndex((s) => isSameDiceSelection(s, item));
@@ -144,15 +152,15 @@ export function CharacterDetailView({
         return [...prev, item];
       });
     },
-    [readOnly]
+    [sheetReadOnly]
   );
 
   const handleSingleAttributeRoll = useCallback(
     (item: DiceSelectionItem) => {
-      if (readOnly || item.type !== "attribute") return;
+      if (sheetReadOnly || item.type !== "attribute") return;
       setSingleAttributeRollSelection([item]);
     },
-    [readOnly]
+    [sheetReadOnly]
   );
 
   const imageEntries = useMemo(
@@ -176,20 +184,20 @@ export function CharacterDetailView({
     const list: CharacterSectionSlide[] = [
       getAttributesSection(
         character,
-        readOnly ? undefined : diceSelection,
-        readOnly ? undefined : handleDiceSelect,
-        readOnly ? undefined : handleSingleAttributeRoll,
-        readOnly
+        sheetReadOnly ? undefined : diceSelection,
+        sheetReadOnly ? undefined : handleDiceSelect,
+        sheetReadOnly ? undefined : handleSingleAttributeRoll,
+        sheetReadOnly
       ),
       getSkillsSection(
         character,
-        readOnly ? undefined : diceSelection,
-        readOnly ? undefined : handleDiceSelect,
-        readOnly
+        sheetReadOnly ? undefined : diceSelection,
+        sheetReadOnly ? undefined : handleDiceSelect,
+        sheetReadOnly
       ),
       getCombatSection(character, {
         onClearReactions: reactionTracking.clearReactions,
-        usedReactions: readOnly ? 0 : reactionTracking.usedReactions,
+        usedReactions: sheetReadOnly ? 0 : reactionTracking.usedReactions,
         initiative: {
           gameDetails: initiativeGameDetails,
           gamesLoading: initiativeGamesLoading,
@@ -199,36 +207,37 @@ export function CharacterDetailView({
             setInitiativeOrderOpen(true);
           },
         },
-        readOnly,
+        readOnly: sheetReadOnly,
       }),
       getGeneralSection(character),
       getHealthSection(character, {
-        readOnly,
+        readOnly: sheetReadOnly,
+        statusEditable: canManageCharacter,
         gameId: activeGameId,
         rollIsPrivate: rollPrivacy.defaultPrivateRoll,
-        mutate: readOnly ? undefined : mutateAction,
-        healthWritePending: readOnly ? false : healthWritePending,
-        settledCrisisHealth: readOnly ? null : settledCrisisHealth,
+        mutate: canManageCharacter ? mutateAction : undefined,
+        healthWritePending: sheetReadOnly ? false : healthWritePending,
+        settledCrisisHealth: sheetReadOnly ? null : settledCrisisHealth,
       }),
     ];
     const pathsSection = getPathsSection(character, {
-      readOnly,
-      mutate: readOnly ? undefined : mutateAction,
+      readOnly: sheetReadOnly,
+      mutate: sheetReadOnly ? undefined : mutateAction,
     });
     if (pathsSection) list.push(pathsSection);
     const featuresSection = getFeaturesSection(character);
     if (featuresSection) list.push(featuresSection);
     list.push(
       getInventorySection(character, activeGameId, {
-        mutate: readOnly ? undefined : mutateAction,
-        readOnly,
+        mutate: sheetReadOnly ? undefined : mutateAction,
+        readOnly: sheetReadOnly,
         rollPrivacy,
       })
     );
     list.push(
       getVehiclesSection(character, activeGameId, {
-        mutate: readOnly ? undefined : mutateAction,
-        readOnly,
+        mutate: sheetReadOnly ? undefined : mutateAction,
+        readOnly: sheetReadOnly,
       })
     );
     list.push(
@@ -236,17 +245,18 @@ export function CharacterDetailView({
         character,
         imageUrls,
         character.id,
-        readOnly ? undefined : mutateAction,
-        readOnly
+        sheetReadOnly ? undefined : mutateAction,
+        sheetReadOnly
       )
     );
-    if (!readOnly && mutateAction) {
+    if (!sheetReadOnly && mutateAction) {
       list.push(getNotesSection(character, mutateAction));
     }
     return applyCharacterSectionOrder(list, user?.characterSectionOrder);
   }, [
     character,
-    readOnly,
+    sheetReadOnly,
+    canManageCharacter,
     diceSelection,
     handleDiceSelect,
     handleSingleAttributeRoll,
@@ -279,15 +289,18 @@ export function CharacterDetailView({
         onActiveGameChange={setActiveGameId}
         avatarUrl={avatarUrl}
         avatarKey={avatarKey}
-        usedReactions={readOnly ? undefined : reactionTracking.usedReactions}
-        onUseReaction={readOnly ? undefined : reactionTracking.useReaction}
-        onHealthUpdate={readOnly ? undefined : updateHealth}
-        onArmourUpdate={readOnly ? undefined : updateArmour}
-        mutate={readOnly ? undefined : mutateAction}
-        onOpenDiceRoller={
-          readOnly ? undefined : () => setDedicatedDiceRollerOpen(true)
+        usedReactions={
+          sheetReadOnly ? undefined : reactionTracking.usedReactions
         }
-        readOnly={readOnly}
+        onUseReaction={sheetReadOnly ? undefined : reactionTracking.useReaction}
+        onHealthUpdate={sheetReadOnly ? undefined : updateHealth}
+        onArmourUpdate={sheetReadOnly ? undefined : updateArmour}
+        mutate={sheetReadOnly ? undefined : mutateAction}
+        onOpenDiceRoller={
+          sheetReadOnly ? undefined : () => setDedicatedDiceRollerOpen(true)
+        }
+        readOnly={sheetReadOnly}
+        showCharacterActions={canManageCharacter}
         rollPrivacy={rollPrivacy}
         className="shrink-0"
       />
@@ -301,7 +314,7 @@ export function CharacterDetailView({
         />
       )}
 
-      {!readOnly &&
+      {!sheetReadOnly &&
         (diceSelection.length === 2 || singleAttributeRollSelection) && (
           <DiceRollModal
             isOpen
@@ -322,7 +335,7 @@ export function CharacterDetailView({
           />
         )}
 
-      {!readOnly && (
+      {!sheetReadOnly && (
         <DedicatedDiceRollModal
           isOpen={dedicatedDiceRollerOpen}
           onClose={() => setDedicatedDiceRollerOpen(false)}
@@ -332,7 +345,7 @@ export function CharacterDetailView({
         />
       )}
 
-      {!readOnly && (
+      {!sheetReadOnly && (
         <>
           <InitiativeRollModal
             isOpen={initiativeRollOpen}

--- a/src/app/components/character/CharacterDetailView.tsx
+++ b/src/app/components/character/CharacterDetailView.tsx
@@ -197,7 +197,12 @@ export function CharacterDetailView({
         readOnly,
       }),
       getGeneralSection(character),
-      getHealthSection(character),
+      getHealthSection(character, {
+        readOnly,
+        gameId: activeGameId,
+        rollIsPrivate: rollPrivacy.defaultPrivateRoll,
+        mutate: readOnly ? undefined : mutateAction,
+      }),
     ];
     const pathsSection = getPathsSection(character, {
       readOnly,

--- a/src/app/components/character/CharacterSectionCarousel.tsx
+++ b/src/app/components/character/CharacterSectionCarousel.tsx
@@ -11,6 +11,8 @@ export interface CharacterSectionSlide {
   title: string;
   /** Rendered opposite the title (e.g. right-aligned) when present */
   titleSupplement?: React.ReactNode;
+  /** Extra classes on the section panel (e.g. crisis highlight). */
+  panelClassName?: string;
   children: React.ReactNode;
 }
 
@@ -54,7 +56,7 @@ export function CharacterSectionCarousel({
             <section
               key={section.id}
               data-slide-index={index}
-              className="flex h-full w-[min(100vw-2rem,28rem)] shrink-0 flex-col rounded-lg border border-black bg-transparent"
+              className={`flex h-full w-[min(100vw-2rem,28rem)] shrink-0 flex-col rounded-lg border border-black bg-transparent ${section.panelClassName ?? ""}`}
               style={{ scrollSnapAlign: "start" }}
             >
               <div className="shrink-0 border-b border-black px-4 py-3 flex items-center justify-between gap-3">

--- a/src/app/components/character/CharacterSectionGrid.tsx
+++ b/src/app/components/character/CharacterSectionGrid.tsx
@@ -20,7 +20,7 @@ export function CharacterSectionGrid({
         {sections.map((section) => (
           <section
             key={section.id}
-            className="flex min-h-0 flex-col rounded-lg border border-black bg-transparent"
+            className={`flex min-h-0 flex-col rounded-lg border border-black bg-transparent ${section.panelClassName ?? ""}`}
           >
             <div className="flex items-center justify-between gap-3 border-b border-black px-4 py-3">
               <h2 className="text-base font-semibold text-black">

--- a/src/app/components/character/CharacterStatusField.tsx
+++ b/src/app/components/character/CharacterStatusField.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Button } from "@/app/components/shared/Button";
+import { SelectDropdown } from "@/app/components/shared/SelectDropdown";
+import { updateCharacterHealth } from "@/lib/api/character";
+import { getUserSafeErrorMessage } from "@/lib/userSafeError";
+import type { Status } from "@prisma/client";
+import { useState } from "react";
+
+const STATUS_OPTIONS: { value: Status; label: string }[] = [
+  { value: "ALIVE", label: "Alive" },
+  { value: "DECEASED", label: "Deceased" },
+  { value: "DERANGED", label: "Deranged" },
+];
+
+function statusToneClassName(status: Status): string {
+  switch (status) {
+    case "ALIVE":
+      return "text-neblirSafe-600";
+    case "DERANGED":
+      return "text-neblirWarning-600";
+    case "DECEASED":
+      return "text-neblirDanger-600";
+  }
+}
+
+function statusDisplayLabel(status: Status): string {
+  return (
+    STATUS_OPTIONS.find((option) => option.value === status)?.label ??
+    String(status).replace(/_/g, " ").toLowerCase()
+  );
+}
+
+type CharacterStatusFieldProps = {
+  characterId: string;
+  status: Status;
+  editable: boolean;
+  disabled?: boolean;
+  mutate: () => Promise<unknown>;
+};
+
+export function CharacterStatusField({
+  characterId,
+  status,
+  editable,
+  disabled = false,
+  mutate,
+}: CharacterStatusFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (editable && editing) {
+    return (
+      <li className="space-y-2 py-3">
+        <SelectDropdown
+          id="character-status"
+          label="Status"
+          placeholder="Select status"
+          value={status}
+          options={STATUS_OPTIONS}
+          disabled={disabled || busy}
+          onChange={(value) => {
+            void (async () => {
+              setBusy(true);
+              setError(null);
+              try {
+                await updateCharacterHealth(characterId, {
+                  status: value as Status,
+                });
+                await mutate();
+                setEditing(false);
+              } catch (err) {
+                setError(getUserSafeErrorMessage(err));
+              } finally {
+                setBusy(false);
+              }
+            })();
+          }}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondaryOutlineXs"
+            disabled={busy}
+            onClick={() => {
+              setError(null);
+              setEditing(false);
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+        {error ? (
+          <p className="text-sm text-neblirDanger-600">{error}</p>
+        ) : null}
+      </li>
+    );
+  }
+
+  return (
+    <li className="grid grid-cols-[auto_1fr_auto] items-center gap-4 py-3">
+      <span className="flex shrink-0 items-center gap-2 text-xs font-medium uppercase tracking-widest text-black">
+        <span className="h-3 w-px bg-black" aria-hidden />
+        Status
+      </span>
+      <span
+        className={`text-center text-base font-semibold capitalize ${statusToneClassName(status)}`}
+      >
+        {statusDisplayLabel(status)}
+      </span>
+      {editable ? (
+        <Button
+          type="button"
+          variant="secondaryOutlineXs"
+          disabled={disabled || busy}
+          onClick={() => {
+            setError(null);
+            setEditing(true);
+          }}
+        >
+          Edit
+        </Button>
+      ) : (
+        <span className="w-0" aria-hidden />
+      )}
+      {error ? (
+        <p className="col-span-3 text-right text-sm text-neblirDanger-600">
+          {error}
+        </p>
+      ) : null}
+    </li>
+  );
+}

--- a/src/app/components/character/CharacterSummaryHeader.tsx
+++ b/src/app/components/character/CharacterSummaryHeader.tsx
@@ -26,6 +26,7 @@ import { useHealthStyles } from "@/hooks/use-health-styles";
 import { useReactionDisplay } from "@/hooks/use-reaction-display";
 import type { KeyedMutator } from "swr";
 import { updateCharacterInventoryEntry } from "@/lib/api/items";
+import type { Status } from "@prisma/client";
 import React, { useCallback, useMemo, useState } from "react";
 import { AttackRollModal } from "@/app/components/combat/AttackRollModal";
 import { CharacterHeaderInfo } from "./CharacterHeaderInfo";
@@ -42,6 +43,11 @@ type HealthPartial = {
   currentMentalHealth?: number;
   seriousPhysicalInjuries?: number;
   seriousTrauma?: number;
+  deathSaves?: { successes: number; failures: number };
+  madnessSaves?: { successes: number; failures: number };
+  status?: Status;
+  physicalHitsAtZero?: number;
+  mentalHitsAtZero?: number;
 };
 
 type ArmourPartial = { armourCurrentHP?: number };
@@ -546,7 +552,15 @@ export function CharacterSummaryHeader({
                 ...(u.seriousInjuries != null && {
                   seriousPhysicalInjuries: u.seriousInjuries,
                 }),
+                ...(u.hitsAtZero != null && {
+                  physicalHitsAtZero: u.hitsAtZero,
+                }),
               })
+            }
+            hitsAtZeroEnabled={
+              health.currentPhysicalHealth === 0 &&
+              health.status !== "DECEASED" &&
+              (health.deathSaves?.successes ?? 0) < 3
             }
           />
         )}
@@ -567,7 +581,15 @@ export function CharacterSummaryHeader({
                 ...(u.seriousTrauma != null && {
                   seriousTrauma: u.seriousTrauma,
                 }),
+                ...(u.hitsAtZero != null && {
+                  mentalHitsAtZero: u.hitsAtZero,
+                }),
               })
+            }
+            hitsAtZeroEnabled={
+              health.currentMentalHealth === 0 &&
+              health.status === "ALIVE" &&
+              (health.madnessSaves?.successes ?? 0) < 3
             }
           />
         )}

--- a/src/app/components/character/CharacterSummaryHeader.tsx
+++ b/src/app/components/character/CharacterSummaryHeader.tsx
@@ -74,6 +74,11 @@ interface CharacterSummaryHeaderProps {
   onOpenDiceRoller?: () => void;
   /** View-only sheet: no rolls, equipping, or stat edits */
   readOnly?: boolean;
+  /**
+   * When set, overrides whether Update / Level-up actions appear under the name.
+   * Defaults to `!readOnly`.
+   */
+  showCharacterActions?: boolean;
   rollPrivacy?: RollPrivacyOptions;
   className?: string;
 }
@@ -92,9 +97,11 @@ export function CharacterSummaryHeader({
   mutate,
   onOpenDiceRoller,
   readOnly = false,
+  showCharacterActions,
   rollPrivacy = { allowPrivateRoll: false, defaultPrivateRoll: false },
   className,
 }: CharacterSummaryHeaderProps) {
+  const characterActionsVisible = showCharacterActions ?? !readOnly;
   const {
     statModalOpen,
     setStatModalOpen,
@@ -295,8 +302,28 @@ export function CharacterSummaryHeader({
               : undefined
           }
           onOpenDiceRoller={onOpenDiceRoller}
-          showCharacterActions={!readOnly}
+          showCharacterActions={characterActionsVisible}
         />
+
+        {character.health.status === "DECEASED" ? (
+          <div
+            className="mt-2 w-full rounded-md border border-neblirDanger bg-paleBlue px-3 py-2 text-center"
+            role="status"
+          >
+            <p className="font-sarpanch text-sm font-bold uppercase tracking-[0.2em] text-neblirDanger-600">
+              Deceased
+            </p>
+          </div>
+        ) : character.health.status === "DERANGED" ? (
+          <div
+            className="mt-2 w-full rounded-md border border-neblirWarning bg-paleBlue px-3 py-2 text-center"
+            role="status"
+          >
+            <p className="font-sarpanch text-sm font-bold uppercase tracking-[0.2em] text-neblirWarning-600">
+              Deranged
+            </p>
+          </div>
+        ) : null}
 
         {activeVehicle ? (
           <div className="mt-1 w-full rounded-lg border border-black bg-paleBlue/40 px-3 py-2 text-sm text-black">

--- a/src/app/components/character/CrisisRollResultModal.tsx
+++ b/src/app/components/character/CrisisRollResultModal.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Button } from "@/app/components/shared/Button";
+
+export type CrisisRollResult = {
+  kind: "death" | "madness";
+  success: boolean;
+  dice: number[];
+  successes: number;
+  failures: number;
+};
+
+type CrisisRollResultModalProps = {
+  result: CrisisRollResult | null;
+  onClose: () => void;
+};
+
+export function CrisisRollResultModal({
+  result,
+  onClose,
+}: CrisisRollResultModalProps) {
+  if (result == null) return null;
+
+  const title = result.kind === "death" ? "Death roll" : "Madness roll";
+  const outcomeLabel = result.success ? "Success" : "Failure";
+  const outcomeClass = result.success
+    ? "text-neblirSafe-600"
+    : "text-neblirDanger-600";
+  const outcomeBorder = result.success
+    ? "border-neblirSafe-400 bg-neblirSafe-200/40"
+    : "border-neblirDanger-400 bg-neblirDanger-200/40";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="crisis-roll-result-title"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-lg border border-black bg-paleBlue/95 shadow-lg backdrop-blur-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-black/15 px-5 pb-3 pt-5 sm:px-6 sm:pb-4 sm:pt-6">
+          <h2
+            id="crisis-roll-result-title"
+            className="text-lg font-semibold text-black"
+          >
+            {title}
+          </h2>
+          <Button
+            type="button"
+            variant="modalCloseLight"
+            fullWidth={false}
+            className="!text-black"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <span className="text-xl leading-none">×</span>
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4 sm:px-6">
+          <div
+            className={`rounded-lg border-2 px-4 py-5 text-center ${outcomeBorder}`}
+          >
+            <p
+              className={`font-sarpanch text-3xl font-bold uppercase tracking-wide ${outcomeClass}`}
+            >
+              {outcomeLabel}
+            </p>
+            <p className="mt-1 text-sm text-black/70">
+              {result.success
+                ? "One success box is marked."
+                : "One failure box is marked."}
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wider text-black/60">
+              Dice ({result.dice.length}d10)
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {result.dice.map((die, index) => {
+                const isHit = die >= 8;
+                return (
+                  <span
+                    key={`${index}-${die}`}
+                    className={`inline-flex h-10 w-10 items-center justify-center rounded border text-base font-bold ${
+                      isHit
+                        ? "border-neblirSafe-400 bg-neblirSafe-200/50 text-neblirSafe-600"
+                        : "border-black/20 bg-white/40 text-black"
+                    }`}
+                  >
+                    {die}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+
+          <p className="text-sm text-black/80">
+            Track:{" "}
+            <span className="font-semibold text-neblirSafe-600">
+              {result.successes} success
+              {result.successes === 1 ? "" : "es"}
+            </span>
+            {" · "}
+            <span className="font-semibold text-neblirDanger-600">
+              {result.failures} failure{result.failures === 1 ? "" : "s"}
+            </span>
+          </p>
+        </div>
+
+        <div className="flex shrink-0 justify-end border-t border-black/15 px-5 py-4 sm:px-6">
+          <Button
+            type="button"
+            variant={result.success ? "lightSafePrimary" : "danger"}
+            fullWidth={false}
+            className="!px-4 !py-2"
+            onClick={onClose}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/character/HealthCrisisPanel.tsx
+++ b/src/app/components/character/HealthCrisisPanel.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Button } from "@/app/components/shared/Button";
-import { SelectDropdown } from "@/app/components/shared/SelectDropdown";
+import {
+  CrisisRollResultModal,
+  type CrisisRollResult,
+} from "@/app/components/character/CrisisRollResultModal";
+import { DangerConfirmModal } from "@/app/components/shared/DangerConfirmModal";
 import {
   crisisPoolIsSuccess,
   deathRollDicePoolSize,
@@ -12,17 +16,10 @@ import { emitRollEvent } from "@/app/lib/roll-event-client";
 import type { CharacterDetail } from "@/app/lib/types/character";
 import { updateCharacterHealth } from "@/lib/api/character";
 import { getUserSafeErrorMessage } from "@/lib/userSafeError";
-import type { Status } from "@prisma/client";
-import { useState } from "react";
-import { DangerConfirmModal } from "@/app/components/shared/DangerConfirmModal";
-
-const STATUS_OPTIONS: { value: Status; label: string }[] = [
-  { value: "ALIVE", label: "Alive" },
-  { value: "DECEASED", label: "Deceased" },
-  { value: "DERANGED", label: "Deranged" },
-];
+import { useEffect, useRef, useState } from "react";
 
 type TrackKind = "death" | "madness";
+type ZeroHpWarning = "physical" | "mental" | "both";
 
 function emptyTrack() {
   return { successes: 0, failures: 0 };
@@ -62,8 +59,15 @@ export function HealthCrisisPanel({
   const madness = health.madnessSaves ?? emptyTrack();
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [lastRoll, setLastRoll] = useState<string | null>(null);
   const [resetKind, setResetKind] = useState<TrackKind | null>(null);
+  const [rollResult, setRollResult] = useState<CrisisRollResult | null>(null);
+  const [zeroHpWarning, setZeroHpWarning] = useState<ZeroHpWarning | null>(
+    null
+  );
+  const prevSettledHpRef = useRef({
+    physical: health.currentPhysicalHealth,
+    mental: health.currentMentalHealth,
+  });
 
   const visibilityHealth =
     healthWritePending && settledCrisisHealth != null
@@ -72,6 +76,27 @@ export function HealthCrisisPanel({
   const visibilityDeath = visibilityHealth.deathSaves ?? emptyTrack();
   const visibilityMadness = visibilityHealth.madnessSaves ?? emptyTrack();
   const crisisActionsLocked = healthWritePending || busy;
+
+  useEffect(() => {
+    if (readOnly || healthWritePending) return;
+    const prev = prevSettledHpRef.current;
+    const nextPhysical = health.currentPhysicalHealth;
+    const nextMental = health.currentMentalHealth;
+    const physicalDropped = prev.physical > 0 && nextPhysical === 0;
+    const mentalDropped = prev.mental > 0 && nextMental === 0;
+    prevSettledHpRef.current = {
+      physical: nextPhysical,
+      mental: nextMental,
+    };
+    if (physicalDropped && mentalDropped) setZeroHpWarning("both");
+    else if (physicalDropped) setZeroHpWarning("physical");
+    else if (mentalDropped) setZeroHpWarning("mental");
+  }, [
+    health.currentPhysicalHealth,
+    health.currentMentalHealth,
+    healthWritePending,
+    readOnly,
+  ]);
 
   const attrs = character.innateAttributes;
   const deathPool = deathRollDicePoolSize(
@@ -137,9 +162,13 @@ export function HealthCrisisPanel({
       successes: success ? Math.min(3, track.successes + 1) : track.successes,
       failures: success ? track.failures : Math.min(3, track.failures + 1),
     };
-    setLastRoll(
-      `${kind === "death" ? "Death" : "Madness"} roll: ${dice.join(", ")} → ${success ? "success" : "failure"}`
-    );
+    setRollResult({
+      kind,
+      success,
+      dice,
+      successes: next.successes,
+      failures: next.failures,
+    });
     await emitRollEvent(gameId, {
       characterId: character.id,
       isPrivate: rollIsPrivate,
@@ -180,24 +209,27 @@ export function HealthCrisisPanel({
     visibilityMadness.successes > 0 ||
     visibilityMadness.failures > 0;
 
+  const zeroWarningCopy =
+    zeroHpWarning === "both"
+      ? {
+          title: "Physical and mental HP are 0",
+          description:
+            "Your character is down on both tracks. The GM may ask you to make death rolls and/or madness rolls from the Health section.",
+        }
+      : zeroHpWarning === "mental"
+        ? {
+            title: "Mental HP is 0",
+            description:
+              "Your character is at 0 mental HP. The GM may ask you to make madness rolls from the Health section.",
+          }
+        : {
+            title: "Physical HP is 0",
+            description:
+              "Your character is at 0 physical HP. The GM may ask you to make death rolls from the Health section.",
+          };
+
   return (
     <div className="space-y-6">
-      {!readOnly ? (
-        <div>
-          <SelectDropdown
-            id="character-status"
-            label="Status"
-            placeholder="Select status"
-            value={health.status}
-            options={STATUS_OPTIONS}
-            disabled={readOnly || crisisActionsLocked}
-            onChange={(value) => {
-              void patchHealth({ status: value as Status });
-            }}
-          />
-        </div>
-      ) : null}
-
       {healthWritePending ? (
         <p className="text-xs text-black/60">
           Saving health… death and madness sections update when the save
@@ -205,7 +237,6 @@ export function HealthCrisisPanel({
         </p>
       ) : null}
 
-      {lastRoll ? <p className="text-sm text-black/80">{lastRoll}</p> : null}
       {error ? <p className="text-sm text-neblirDanger-600">{error}</p> : null}
 
       {showDeath ? (
@@ -291,6 +322,21 @@ export function HealthCrisisPanel({
             void patchHealth({ madnessSaves: emptyTrack() });
           }
         }}
+      />
+
+      <DangerConfirmModal
+        isOpen={zeroHpWarning != null}
+        title={zeroWarningCopy.title}
+        description={zeroWarningCopy.description}
+        confirmLabel="Got it"
+        hideCancel
+        onCancel={() => setZeroHpWarning(null)}
+        onConfirm={() => setZeroHpWarning(null)}
+      />
+
+      <CrisisRollResultModal
+        result={rollResult}
+        onClose={() => setRollResult(null)}
       />
     </div>
   );

--- a/src/app/components/character/HealthCrisisPanel.tsx
+++ b/src/app/components/character/HealthCrisisPanel.tsx
@@ -34,6 +34,18 @@ type HealthCrisisPanelProps = {
   gameId: string | null;
   rollIsPrivate?: boolean;
   mutate: () => Promise<unknown>;
+  /**
+   * While a debounced header health write is in flight, freeze death/madness
+   * section visibility on this snapshot so optimistic HP changes do not flash
+   * the crisis UI before the PATCH completes.
+   */
+  healthWritePending?: boolean;
+  settledCrisisHealth?: {
+    currentPhysicalHealth: number;
+    currentMentalHealth: number;
+    deathSaves: { successes: number; failures: number } | null | undefined;
+    madnessSaves: { successes: number; failures: number } | null | undefined;
+  } | null;
 };
 
 export function HealthCrisisPanel({
@@ -42,6 +54,8 @@ export function HealthCrisisPanel({
   gameId,
   rollIsPrivate = false,
   mutate,
+  healthWritePending = false,
+  settledCrisisHealth = null,
 }: HealthCrisisPanelProps) {
   const health = character.health;
   const death = health.deathSaves ?? emptyTrack();
@@ -50,6 +64,14 @@ export function HealthCrisisPanel({
   const [busy, setBusy] = useState(false);
   const [lastRoll, setLastRoll] = useState<string | null>(null);
   const [resetKind, setResetKind] = useState<TrackKind | null>(null);
+
+  const visibilityHealth =
+    healthWritePending && settledCrisisHealth != null
+      ? settledCrisisHealth
+      : health;
+  const visibilityDeath = visibilityHealth.deathSaves ?? emptyTrack();
+  const visibilityMadness = visibilityHealth.madnessSaves ?? emptyTrack();
+  const crisisActionsLocked = healthWritePending || busy;
 
   const attrs = character.innateAttributes;
   const deathPool = deathRollDicePoolSize(
@@ -150,13 +172,13 @@ export function HealthCrisisPanel({
   };
 
   const showDeath =
-    health.currentPhysicalHealth === 0 ||
-    death.successes > 0 ||
-    death.failures > 0;
+    visibilityHealth.currentPhysicalHealth === 0 ||
+    visibilityDeath.successes > 0 ||
+    visibilityDeath.failures > 0;
   const showMadness =
-    health.currentMentalHealth === 0 ||
-    madness.successes > 0 ||
-    madness.failures > 0;
+    visibilityHealth.currentMentalHealth === 0 ||
+    visibilityMadness.successes > 0 ||
+    visibilityMadness.failures > 0;
 
   return (
     <div className="space-y-6">
@@ -168,12 +190,19 @@ export function HealthCrisisPanel({
             placeholder="Select status"
             value={health.status}
             options={STATUS_OPTIONS}
-            disabled={busy}
+            disabled={readOnly || crisisActionsLocked}
             onChange={(value) => {
               void patchHealth({ status: value as Status });
             }}
           />
         </div>
+      ) : null}
+
+      {healthWritePending ? (
+        <p className="text-xs text-black/60">
+          Saving health… death and madness sections update when the save
+          finishes.
+        </p>
       ) : null}
 
       {lastRoll ? <p className="text-sm text-black/80">{lastRoll}</p> : null}
@@ -184,17 +213,23 @@ export function HealthCrisisPanel({
           title="Death rolls"
           successes={death.successes}
           failures={death.failures}
-          makeDisabled={readOnly || busy || deathLocked}
-          makeTitle={deathLocked ? deathLockReason : undefined}
+          makeDisabled={readOnly || crisisActionsLocked || deathLocked}
+          makeTitle={
+            healthWritePending
+              ? "Wait for the health save to finish before rolling."
+              : deathLocked
+                ? deathLockReason
+                : undefined
+          }
           makeLabel="Make death roll"
           resetDisabled={
             readOnly ||
-            busy ||
+            crisisActionsLocked ||
             deathBoxesLocked ||
             health.currentPhysicalHealth !== 0 ||
             (death.successes === 0 && death.failures === 0)
           }
-          boxesDisabled={readOnly || busy || deathBoxesLocked}
+          boxesDisabled={readOnly || crisisActionsLocked || deathBoxesLocked}
           boxesTitle={
             deathBoxesLocked
               ? "Death-roll boxes cannot be changed while status is deceased."
@@ -211,17 +246,23 @@ export function HealthCrisisPanel({
           title="Madness rolls"
           successes={madness.successes}
           failures={madness.failures}
-          makeDisabled={readOnly || busy || madnessLocked}
-          makeTitle={madnessLocked ? madnessLockReason : undefined}
+          makeDisabled={readOnly || crisisActionsLocked || madnessLocked}
+          makeTitle={
+            healthWritePending
+              ? "Wait for the health save to finish before rolling."
+              : madnessLocked
+                ? madnessLockReason
+                : undefined
+          }
           makeLabel="Make madness roll"
           resetDisabled={
             readOnly ||
-            busy ||
+            crisisActionsLocked ||
             madnessBoxesLocked ||
             health.currentMentalHealth !== 0 ||
             (madness.successes === 0 && madness.failures === 0)
           }
-          boxesDisabled={readOnly || busy || madnessBoxesLocked}
+          boxesDisabled={readOnly || crisisActionsLocked || madnessBoxesLocked}
           boxesTitle={
             madnessBoxesLocked
               ? "Madness-roll boxes cannot be changed while status is deranged or deceased."

--- a/src/app/components/character/HealthCrisisPanel.tsx
+++ b/src/app/components/character/HealthCrisisPanel.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { Button } from "@/app/components/shared/Button";
+import { SelectDropdown } from "@/app/components/shared/SelectDropdown";
+import {
+  crisisPoolIsSuccess,
+  deathRollDicePoolSize,
+  madnessRollDicePoolSize,
+} from "@/app/lib/crisisRoll";
+import { rollDie } from "@/app/lib/general-dice";
+import { emitRollEvent } from "@/app/lib/roll-event-client";
+import type { CharacterDetail } from "@/app/lib/types/character";
+import { updateCharacterHealth } from "@/lib/api/character";
+import { getUserSafeErrorMessage } from "@/lib/userSafeError";
+import type { Status } from "@prisma/client";
+import { useState } from "react";
+import { DangerConfirmModal } from "@/app/components/shared/DangerConfirmModal";
+
+const STATUS_OPTIONS: { value: Status; label: string }[] = [
+  { value: "ALIVE", label: "Alive" },
+  { value: "DECEASED", label: "Deceased" },
+  { value: "DERANGED", label: "Deranged" },
+];
+
+type TrackKind = "death" | "madness";
+
+function emptyTrack() {
+  return { successes: 0, failures: 0 };
+}
+
+type HealthCrisisPanelProps = {
+  character: CharacterDetail;
+  readOnly: boolean;
+  gameId: string | null;
+  rollIsPrivate?: boolean;
+  mutate: () => Promise<unknown>;
+};
+
+export function HealthCrisisPanel({
+  character,
+  readOnly,
+  gameId,
+  rollIsPrivate = false,
+  mutate,
+}: HealthCrisisPanelProps) {
+  const health = character.health;
+  const death = health.deathSaves ?? emptyTrack();
+  const madness = health.madnessSaves ?? emptyTrack();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [lastRoll, setLastRoll] = useState<string | null>(null);
+  const [resetKind, setResetKind] = useState<TrackKind | null>(null);
+
+  const attrs = character.innateAttributes;
+  const deathPool = deathRollDicePoolSize(
+    attrs.strength.resilience,
+    attrs.constitution.stamina,
+    health.seriousPhysicalInjuries
+  );
+  const madnessPool = madnessRollDicePoolSize(
+    attrs.personality.mentality,
+    health.seriousTrauma
+  );
+
+  const deathStable = death.successes >= 3 && death.failures < 3;
+  const madnessComposed = madness.successes >= 3 && madness.failures < 3;
+  const deathLocked =
+    health.status === "DECEASED" ||
+    deathStable ||
+    health.currentPhysicalHealth !== 0;
+  const madnessLocked =
+    health.status !== "ALIVE" ||
+    madnessComposed ||
+    health.currentMentalHealth !== 0;
+  const deathBoxesLocked = health.status === "DECEASED";
+  const madnessBoxesLocked =
+    health.status === "DECEASED" || health.status === "DERANGED";
+
+  const deathLockReason =
+    health.status === "DECEASED"
+      ? "Death rolls are locked while status is deceased. Set status to alive if this was a mistake."
+      : deathStable
+        ? "This character is stable. Heal above 0 HP or reset the death roll to start a new cycle."
+        : "Death rolls are only available at 0 physical HP.";
+  const madnessLockReason =
+    health.status === "DECEASED"
+      ? "Madness rolls are locked while status is deceased."
+      : health.status === "DERANGED"
+        ? "Madness rolls are locked while status is deranged. Set status to alive if this was a mistake."
+        : madnessComposed
+          ? "This character is composed. Heal above 0 mental HP or reset the madness roll to start a new cycle."
+          : "Madness rolls are only available at 0 mental HP while alive.";
+
+  const patchHealth = async (
+    body: Parameters<typeof updateCharacterHealth>[1]
+  ) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateCharacterHealth(character.id, body);
+      await mutate();
+    } catch (e) {
+      setError(getUserSafeErrorMessage(e, "Failed to update health"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const makeRoll = async (kind: TrackKind) => {
+    const pool = kind === "death" ? deathPool : madnessPool;
+    const dice = Array.from({ length: pool }, () => rollDie(10));
+    const success = crisisPoolIsSuccess(dice);
+    const track = kind === "death" ? death : madness;
+    const next = {
+      successes: success ? Math.min(3, track.successes + 1) : track.successes,
+      failures: success ? track.failures : Math.min(3, track.failures + 1),
+    };
+    setLastRoll(
+      `${kind === "death" ? "Death" : "Madness"} roll: ${dice.join(", ")} → ${success ? "success" : "failure"}`
+    );
+    await emitRollEvent(gameId, {
+      characterId: character.id,
+      isPrivate: rollIsPrivate,
+      rollType: "GENERAL_ROLL",
+      diceExpression: `${pool}d10`,
+      results: dice,
+      total: dice.reduce((sum, n) => sum + n, 0),
+      metadata: {
+        source: kind === "death" ? "deathRoll" : "madnessRoll",
+        outcome: success ? "success" : "failure",
+      },
+    });
+    await patchHealth(
+      kind === "death" ? { deathSaves: next } : { madnessSaves: next }
+    );
+  };
+
+  const toggleBox = (
+    kind: TrackKind,
+    side: "successes" | "failures",
+    index: number
+  ) => {
+    const track = kind === "death" ? { ...death } : { ...madness };
+    const current = track[side];
+    const nextCount = index < current ? index : index + 1;
+    track[side] = nextCount;
+    void patchHealth(
+      kind === "death" ? { deathSaves: track } : { madnessSaves: track }
+    );
+  };
+
+  const showDeath =
+    health.currentPhysicalHealth === 0 ||
+    death.successes > 0 ||
+    death.failures > 0;
+  const showMadness =
+    health.currentMentalHealth === 0 ||
+    madness.successes > 0 ||
+    madness.failures > 0;
+
+  return (
+    <div className="space-y-6">
+      {!readOnly ? (
+        <div>
+          <SelectDropdown
+            id="character-status"
+            label="Status"
+            placeholder="Select status"
+            value={health.status}
+            options={STATUS_OPTIONS}
+            disabled={busy}
+            onChange={(value) => {
+              void patchHealth({ status: value as Status });
+            }}
+          />
+        </div>
+      ) : null}
+
+      {lastRoll ? <p className="text-sm text-black/80">{lastRoll}</p> : null}
+      {error ? <p className="text-sm text-neblirDanger-600">{error}</p> : null}
+
+      {showDeath ? (
+        <CrisisTrackBlock
+          title="Death rolls"
+          successes={death.successes}
+          failures={death.failures}
+          makeDisabled={readOnly || busy || deathLocked}
+          makeTitle={deathLocked ? deathLockReason : undefined}
+          makeLabel="Make death roll"
+          resetDisabled={
+            readOnly ||
+            busy ||
+            deathBoxesLocked ||
+            health.currentPhysicalHealth !== 0 ||
+            (death.successes === 0 && death.failures === 0)
+          }
+          boxesDisabled={readOnly || busy || deathBoxesLocked}
+          boxesTitle={
+            deathBoxesLocked
+              ? "Death-roll boxes cannot be changed while status is deceased."
+              : undefined
+          }
+          onMake={() => void makeRoll("death")}
+          onReset={() => setResetKind("death")}
+          onToggle={(side, index) => toggleBox("death", side, index)}
+        />
+      ) : null}
+
+      {showMadness ? (
+        <CrisisTrackBlock
+          title="Madness rolls"
+          successes={madness.successes}
+          failures={madness.failures}
+          makeDisabled={readOnly || busy || madnessLocked}
+          makeTitle={madnessLocked ? madnessLockReason : undefined}
+          makeLabel="Make madness roll"
+          resetDisabled={
+            readOnly ||
+            busy ||
+            madnessBoxesLocked ||
+            health.currentMentalHealth !== 0 ||
+            (madness.successes === 0 && madness.failures === 0)
+          }
+          boxesDisabled={readOnly || busy || madnessBoxesLocked}
+          boxesTitle={
+            madnessBoxesLocked
+              ? "Madness-roll boxes cannot be changed while status is deranged or deceased."
+              : undefined
+          }
+          onMake={() => void makeRoll("madness")}
+          onReset={() => setResetKind("madness")}
+          onToggle={(side, index) => toggleBox("madness", side, index)}
+        />
+      ) : null}
+
+      <DangerConfirmModal
+        isOpen={resetKind != null}
+        title={
+          resetKind === "madness" ? "Reset madness roll?" : "Reset death roll?"
+        }
+        description="This clears all success and failure boxes so a new cycle can begin."
+        confirmLabel="Reset"
+        onCancel={() => setResetKind(null)}
+        onConfirm={() => {
+          const kind = resetKind;
+          setResetKind(null);
+          if (kind === "death") {
+            void patchHealth({ deathSaves: emptyTrack() });
+          } else if (kind === "madness") {
+            void patchHealth({ madnessSaves: emptyTrack() });
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+function CrisisTrackBlock({
+  title,
+  successes,
+  failures,
+  makeDisabled,
+  makeTitle,
+  makeLabel,
+  resetDisabled,
+  boxesDisabled,
+  boxesTitle,
+  onMake,
+  onReset,
+  onToggle,
+}: {
+  title: string;
+  successes: number;
+  failures: number;
+  makeDisabled: boolean;
+  makeTitle?: string;
+  makeLabel: string;
+  resetDisabled: boolean;
+  boxesDisabled: boolean;
+  boxesTitle?: string;
+  onMake: () => void;
+  onReset: () => void;
+  onToggle: (side: "successes" | "failures", index: number) => void;
+}) {
+  return (
+    <div className="border-t border-black pt-4">
+      <span className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-widest text-black">
+        <span className="h-3 w-px bg-black" aria-hidden />
+        {title}
+      </span>
+      <div className="mt-5 flex w-full gap-6" title={boxesTitle}>
+        <TrackBoxes
+          label="Successes"
+          filled={successes}
+          mark="✓"
+          disabled={boxesDisabled}
+          onToggle={(index) => onToggle("successes", index)}
+        />
+        <TrackBoxes
+          label="Failures"
+          filled={failures}
+          mark="✗"
+          disabled={boxesDisabled}
+          onToggle={(index) => onToggle("failures", index)}
+        />
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <span title={makeTitle}>
+          <Button
+            type="button"
+            variant="primarySm"
+            fullWidth={false}
+            disabled={makeDisabled}
+            onClick={onMake}
+          >
+            {makeLabel}
+          </Button>
+        </span>
+        <span title={resetDisabled ? boxesTitle : undefined}>
+          <Button
+            type="button"
+            variant="secondaryOutlineXs"
+            fullWidth={false}
+            disabled={resetDisabled}
+            onClick={onReset}
+          >
+            Reset {title.toLowerCase()}
+          </Button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TrackBoxes({
+  label,
+  filled,
+  mark,
+  disabled,
+  onToggle,
+}: {
+  label: string;
+  filled: number;
+  mark: string;
+  disabled: boolean;
+  onToggle: (index: number) => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center gap-1.5">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-black">
+        {label}
+      </span>
+      <div className="flex gap-1">
+        {[0, 1, 2].map((i) => (
+          <Button
+            key={i}
+            type="button"
+            variant="secondaryOutlineXs"
+            fullWidth={false}
+            disabled={disabled}
+            aria-label={`${label} ${i + 1}`}
+            className="h-8 w-8 min-w-8 p-0"
+            onClick={() => onToggle(i)}
+          >
+            {i < filled ? mark : ""}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/character/ItemDetailModal.tsx
+++ b/src/app/components/character/ItemDetailModal.tsx
@@ -23,6 +23,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ItemDamageRollModal } from "./itemDetailModal/ItemDamageRollModal";
 import { ItemDetailExtraWeaponGrid } from "./itemDetailModal/ItemDetailExtraWeaponGrid";
 import { ItemDetailEquipSection } from "./itemDetailModal/ItemDetailEquipSection";
+import { ItemDetailHoldingEditor } from "./itemDetailModal/ItemDetailHoldingEditor";
 import { ItemDetailGiveRemoveSection } from "./itemDetailModal/ItemDetailGiveRemoveSection";
 import { ItemDetailLocationSection } from "./itemDetailModal/ItemDetailLocationSection";
 import { ItemDetailSummaryGrid } from "./itemDetailModal/ItemDetailSummaryGrid";
@@ -303,6 +304,16 @@ export function ItemDetailModal({
               />
             </div>
           )}
+
+          <ItemDetailHoldingEditor
+            key={entry.id}
+            characterId={characterId}
+            itemCharacterId={entry.id}
+            nickname={entry.customName ?? ""}
+            quantity={entry.quantity}
+            mutate={mutate}
+            onHoldingRemoved={onClose}
+          />
 
           <ItemDetailSummaryGrid
             entry={entry}

--- a/src/app/components/character/StatEditModal.tsx
+++ b/src/app/components/character/StatEditModal.tsx
@@ -21,7 +21,10 @@ export interface StatEditModalProps {
     currentHP?: number;
     seriousInjuries?: number;
     seriousTrauma?: number;
+    hitsAtZero?: number;
   }) => void;
+  /** When true, − at 0 HP records crisis-track failures instead of lowering HP. */
+  hitsAtZeroEnabled?: boolean;
 }
 
 type SessionSnapshot = {
@@ -44,12 +47,14 @@ function QuickAdjustRow({
   min,
   max,
   onAdjust,
+  decreaseDisabled,
 }: {
   label: string;
   value: number;
   min: number;
   max: number;
   onAdjust: (delta: number) => void;
+  decreaseDisabled?: boolean;
 }) {
   return (
     <div className="flex items-center justify-between gap-4">
@@ -61,7 +66,7 @@ function QuickAdjustRow({
           fullWidth={false}
           className="disabled:!opacity-40"
           onClick={() => onAdjust(-1)}
-          disabled={value <= min}
+          disabled={decreaseDisabled ?? value <= min}
           aria-label={`Decrease ${label}`}
         >
           −
@@ -94,6 +99,7 @@ export function StatEditModal({
   seriousInjuries = 0,
   seriousTrauma = 0,
   onUpdate,
+  hitsAtZeroEnabled = false,
 }: StatEditModalProps) {
   /** Frozen for this mount; parent remounts with `key` when the modal is opened. */
   const [sessionStart] = useState<SessionSnapshot>(() => ({
@@ -104,6 +110,7 @@ export function StatEditModal({
   const [draftHP, setDraftHP] = useState(() => currentHP);
   const [draftInjuries, setDraftInjuries] = useState(() => seriousInjuries);
   const [draftTrauma, setDraftTrauma] = useState(() => seriousTrauma);
+  const [draftHitsAtZero, setDraftHitsAtZero] = useState(0);
 
   const flushSessionToParent = () => {
     const start = sessionStart;
@@ -118,11 +125,13 @@ export function StatEditModal({
         currentHP?: number;
         seriousInjuries?: number;
         seriousTrauma?: number;
+        hitsAtZero?: number;
       } = {};
       if (draftHP !== start.hp) updates.currentHP = draftHP;
       if (finalInjuries !== start.injuries) {
         updates.seriousInjuries = finalInjuries;
       }
+      if (draftHitsAtZero > 0) updates.hitsAtZero = draftHitsAtZero;
       if (Object.keys(updates).length > 0) onUpdate(updates);
     } else if (type === "mental") {
       const lost = sessionHpLost(start.hp, draftHP);
@@ -132,9 +141,11 @@ export function StatEditModal({
         currentHP?: number;
         seriousInjuries?: number;
         seriousTrauma?: number;
+        hitsAtZero?: number;
       } = {};
       if (draftHP !== start.hp) updates.currentHP = draftHP;
       if (finalTrauma !== start.trauma) updates.seriousTrauma = finalTrauma;
+      if (draftHitsAtZero > 0) updates.hitsAtZero = draftHitsAtZero;
       if (Object.keys(updates).length > 0) onUpdate(updates);
     } else {
       if (draftHP !== start.hp) onUpdate({ currentHP: draftHP });
@@ -174,6 +185,16 @@ export function StatEditModal({
       : draftTrauma;
 
   const handleHPAdjust = (delta: number) => {
+    if (hitsAtZeroEnabled && sessionStart.hp === 0 && draftHP === 0) {
+      if (delta < 0) {
+        setDraftHitsAtZero((n) => Math.min(3, n + 1));
+        return;
+      }
+      if (delta > 0 && draftHitsAtZero > 0) {
+        setDraftHitsAtZero((n) => Math.max(0, n - 1));
+        return;
+      }
+    }
     setDraftHP((prev) => Math.max(0, Math.min(maxHP, prev + delta)));
   };
 
@@ -235,8 +256,20 @@ export function StatEditModal({
             min={0}
             max={maxHP}
             onAdjust={handleHPAdjust}
+            decreaseDisabled={
+              draftHP <= 0 &&
+              !(hitsAtZeroEnabled && sessionStart.hp === 0) &&
+              draftHitsAtZero === 0
+            }
           />
         )}
+
+        {hitsAtZeroEnabled && draftHitsAtZero > 0 ? (
+          <p className="text-sm text-white/80">
+            Hits at 0 HP this edit: {draftHitsAtZero} (each marks a crisis
+            failure)
+          </p>
+        ) : null}
 
         {type === "physical" && (
           <QuickAdjustRow

--- a/src/app/components/character/VehicleDetailModal.tsx
+++ b/src/app/components/character/VehicleDetailModal.tsx
@@ -8,6 +8,7 @@ import {
   statusClassName,
   VEHICLE_STATUS_LABELS,
 } from "@/app/components/character/vehicleDetailModal/VehicleDetailStatRows";
+import { VehicleHoldingEditor } from "@/app/components/character/vehicleDetailModal/VehicleHoldingEditor";
 import { Button } from "@/app/components/shared/Button";
 import { Checkbox } from "@/app/components/shared/Checkbox";
 import { DangerConfirmModal } from "@/app/components/shared/DangerConfirmModal";
@@ -412,6 +413,16 @@ export function VehicleDetailModal({
           </div>
         ) : null}
 
+        <VehicleHoldingEditor
+          key={entry.id}
+          characterId={characterId}
+          vehicleCharacterId={entry.id}
+          nickname={entry.customName ?? ""}
+          maxHpBonus={entry.maxHpBonus}
+          disabled={busyAction != null}
+          mutate={mutateAction}
+        />
+
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           <CurrentHpAdjustRow
             currentHp={entry.currentHp}
@@ -422,7 +433,6 @@ export function VehicleDetailModal({
             }}
           />
           <DetailRow label="Effective max HP" value={entry.effectiveMaxHp} />
-          <DetailRow label="Max HP bonus" value={entry.maxHpBonus} />
           <DetailRow
             label={VEHICLE_COMBAT_SPEED_LABEL}
             hint={VEHICLE_COMBAT_SPEED_HELP}

--- a/src/app/components/character/itemDetailModal/ItemDetailHoldingEditor.tsx
+++ b/src/app/components/character/itemDetailModal/ItemDetailHoldingEditor.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Button } from "@/app/components/shared/Button";
+import { FieldLabel } from "@/app/components/shared/FieldLabel";
+import { NumberField } from "@/app/components/shared/NumberField";
+import { TextField } from "@/app/components/shared/TextField";
+import { MAX_STACK_QUANTITY } from "@/app/lib/constants/inventory";
+import { updateCharacterInventoryEntry } from "@/lib/api/items";
+import { getUserSafeErrorMessage } from "@/lib/userSafeError";
+import { useState } from "react";
+
+type ItemDetailHoldingEditorProps = {
+  characterId: string;
+  itemCharacterId: string;
+  nickname: string;
+  quantity: number;
+  mutate: () => Promise<unknown>;
+  onHoldingRemoved: () => void;
+};
+
+export function ItemDetailHoldingEditor({
+  characterId,
+  itemCharacterId,
+  nickname,
+  quantity,
+  mutate,
+  onHoldingRemoved,
+}: ItemDetailHoldingEditorProps) {
+  const [nicknameDraft, setNicknameDraft] = useState(nickname);
+  const [quantityDraft, setQuantityDraft] = useState(String(quantity));
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const saveNickname = async () => {
+    const next = nicknameDraft.trim();
+    const current = nickname.trim();
+    if (next === current) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await updateCharacterInventoryEntry(characterId, itemCharacterId, {
+        action: "setCustomName",
+        customName: next.length > 0 ? next : null,
+      });
+      await mutate();
+    } catch (e) {
+      setError(getUserSafeErrorMessage(e, "Failed to update nickname"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveQuantity = async (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setQuantityDraft(String(quantity));
+      return;
+    }
+    const next = Math.min(MAX_STACK_QUANTITY, parsed);
+    if (next === quantity) {
+      setQuantityDraft(String(quantity));
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await updateCharacterInventoryEntry(
+        characterId,
+        itemCharacterId,
+        { action: "setQuantity", quantity: next }
+      );
+      await mutate();
+      if (updated == null || next === 0) {
+        onHoldingRemoved();
+        return;
+      }
+      setQuantityDraft(String(next));
+    } catch (e) {
+      setQuantityDraft(String(quantity));
+      setError(getUserSafeErrorMessage(e, "Failed to update quantity"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <FieldLabel id={`item-nickname-${itemCharacterId}`} label="Nickname" />
+        <TextField
+          id={`item-nickname-${itemCharacterId}`}
+          variant="dark"
+          value={nicknameDraft}
+          disabled={busy}
+          onChange={(e) => setNicknameDraft(e.target.value)}
+          onBlur={() => void saveNickname()}
+        />
+      </div>
+      <div>
+        <FieldLabel
+          id={`item-quantity-${itemCharacterId}`}
+          label="Quantity"
+          required
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="modalIconStepperCompact"
+            fullWidth={false}
+            disabled={busy || quantity <= 0}
+            aria-label="Decrease quantity"
+            onClick={() => void saveQuantity(String(quantity - 1))}
+          >
+            −
+          </Button>
+          <NumberField
+            id={`item-quantity-${itemCharacterId}`}
+            variant="dark"
+            density="compact"
+            min={0}
+            max={MAX_STACK_QUANTITY}
+            value={quantityDraft}
+            disabled={busy}
+            onChange={setQuantityDraft}
+            onBlur={() => void saveQuantity(quantityDraft)}
+          />
+          <Button
+            type="button"
+            variant="modalIconStepperCompact"
+            fullWidth={false}
+            disabled={busy || quantity >= MAX_STACK_QUANTITY}
+            aria-label="Increase quantity"
+            onClick={() => void saveQuantity(String(quantity + 1))}
+          >
+            +
+          </Button>
+        </div>
+      </div>
+      {error ? <p className="text-xs text-neblirDanger-300">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/app/components/character/itemDetailModal/ItemDetailSummaryGrid.tsx
+++ b/src/app/components/character/itemDetailModal/ItemDetailSummaryGrid.tsx
@@ -42,9 +42,6 @@ export function ItemDetailSummaryGrid({
       <DetailField label="Weight">
         {item?.weight != null ? `${item.weight} kg` : "—"}
       </DetailField>
-      <DetailField label="Quantity" className="col-span-2">
-        {entry.quantity}
-      </DetailField>
 
       {item?.equippable ? (
         <>

--- a/src/app/components/character/vehicleDetailModal/VehicleHoldingEditor.tsx
+++ b/src/app/components/character/vehicleDetailModal/VehicleHoldingEditor.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { FieldLabel } from "@/app/components/shared/FieldLabel";
+import { NumberField } from "@/app/components/shared/NumberField";
+import { TextField } from "@/app/components/shared/TextField";
+import { updateCharacterVehicleEntry } from "@/lib/api/vehicles";
+import { getUserSafeErrorMessage } from "@/lib/userSafeError";
+import { useState } from "react";
+
+type VehicleHoldingEditorProps = {
+  characterId: string;
+  vehicleCharacterId: string;
+  nickname: string;
+  maxHpBonus: number;
+  disabled: boolean;
+  mutate: () => Promise<unknown>;
+};
+
+export function VehicleHoldingEditor({
+  characterId,
+  vehicleCharacterId,
+  nickname,
+  maxHpBonus,
+  disabled,
+  mutate,
+}: VehicleHoldingEditorProps) {
+  const [nicknameDraft, setNicknameDraft] = useState(nickname);
+  const [bonusDraft, setBonusDraft] = useState(String(maxHpBonus));
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const locked = disabled || busy;
+
+  const saveNickname = async () => {
+    const next = nicknameDraft.trim();
+    if (next === nickname.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await updateCharacterVehicleEntry(characterId, vehicleCharacterId, {
+        action: "setCustomName",
+        customName: next.length > 0 ? next : null,
+      });
+      await mutate();
+    } catch (e) {
+      setError(getUserSafeErrorMessage(e, "Failed to update nickname"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveBonus = async (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) {
+      setBonusDraft(String(maxHpBonus));
+      return;
+    }
+    if (parsed === maxHpBonus) {
+      setBonusDraft(String(maxHpBonus));
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await updateCharacterVehicleEntry(characterId, vehicleCharacterId, {
+        action: "setMaxHpBonus",
+        maxHpBonus: parsed,
+      });
+      await mutate();
+      setBonusDraft(String(parsed));
+    } catch (e) {
+      setBonusDraft(String(maxHpBonus));
+      setError(getUserSafeErrorMessage(e, "Failed to update max HP bonus"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <div className="sm:col-span-2">
+        <FieldLabel
+          id={`vehicle-nickname-${vehicleCharacterId}`}
+          label="Nickname"
+        />
+        <TextField
+          id={`vehicle-nickname-${vehicleCharacterId}`}
+          variant="dark"
+          value={nicknameDraft}
+          disabled={locked}
+          onChange={(e) => setNicknameDraft(e.target.value)}
+          onBlur={() => void saveNickname()}
+        />
+      </div>
+      <div>
+        <FieldLabel
+          id={`vehicle-max-hp-bonus-${vehicleCharacterId}`}
+          label="Max HP bonus"
+          required
+        />
+        <NumberField
+          id={`vehicle-max-hp-bonus-${vehicleCharacterId}`}
+          variant="dark"
+          value={bonusDraft}
+          disabled={locked}
+          onChange={setBonusDraft}
+          onBlur={() => void saveBonus(bonusDraft)}
+        />
+      </div>
+      {error ? (
+        <p className="sm:col-span-2 text-xs text-neblirDanger-300">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/lib/applyCharacterHealthPatch.ts
+++ b/src/app/lib/applyCharacterHealthPatch.ts
@@ -1,0 +1,234 @@
+import type { Status } from "@prisma/client";
+
+export type CrisisTrack = {
+  successes: number;
+  failures: number;
+};
+
+export type CharacterHealthSnapshot = {
+  currentPhysicalHealth: number;
+  currentMentalHealth: number;
+  maxPhysicalHealth: number;
+  maxMentalHealth: number;
+  seriousPhysicalInjuries: number;
+  seriousTrauma: number;
+  deathSaves: CrisisTrack;
+  madnessSaves?: CrisisTrack;
+  status: Status;
+};
+
+export type CharacterHealthPatch = {
+  currentPhysicalHealth?: number;
+  currentMentalHealth?: number;
+  seriousPhysicalInjuries?: number;
+  seriousTrauma?: number;
+  deathSaves?: CrisisTrack;
+  madnessSaves?: CrisisTrack;
+  status?: Status;
+  physicalHitsAtZero?: number;
+  mentalHitsAtZero?: number;
+};
+
+export type ApplyHealthResult =
+  | { ok: true; health: CharacterHealthSnapshot }
+  | { ok: false; error: string };
+
+function clampTrack(track: CrisisTrack): CrisisTrack {
+  return {
+    successes: Math.max(0, Math.min(3, track.successes)),
+    failures: Math.max(0, Math.min(3, track.failures)),
+  };
+}
+
+function tracksEqual(a: CrisisTrack, b: CrisisTrack): boolean {
+  return a.successes === b.successes && a.failures === b.failures;
+}
+
+function emptyTrack(): CrisisTrack {
+  return { successes: 0, failures: 0 };
+}
+
+function isStable(track: CrisisTrack): boolean {
+  return track.successes >= 3 && track.failures < 3;
+}
+
+function inDeathCycle(health: CharacterHealthSnapshot): boolean {
+  return (
+    health.currentPhysicalHealth === 0 &&
+    health.status !== "DECEASED" &&
+    !isStable(health.deathSaves)
+  );
+}
+
+function inMadnessCycle(health: CharacterHealthSnapshot): boolean {
+  const track = health.madnessSaves ?? emptyTrack();
+  return (
+    health.currentMentalHealth === 0 &&
+    health.status === "ALIVE" &&
+    !isStable(track)
+  );
+}
+
+export function applyCharacterHealthPatch(
+  existing: CharacterHealthSnapshot,
+  patch: CharacterHealthPatch
+): ApplyHealthResult {
+  const existingDeath = clampTrack(existing.deathSaves);
+  const existingMadness = clampTrack(existing.madnessSaves ?? emptyTrack());
+
+  if (
+    existing.status === "DECEASED" &&
+    patch.deathSaves != null &&
+    !tracksEqual(clampTrack(patch.deathSaves), existingDeath)
+  ) {
+    return {
+      ok: false,
+      error: "Death-roll boxes cannot be changed while status is deceased.",
+    };
+  }
+
+  if (
+    (existing.status === "DECEASED" || existing.status === "DERANGED") &&
+    patch.madnessSaves != null &&
+    !tracksEqual(clampTrack(patch.madnessSaves), existingMadness)
+  ) {
+    return {
+      ok: false,
+      error:
+        "Madness-roll boxes cannot be changed while status is deranged or deceased.",
+    };
+  }
+
+  let deathSaves = existingDeath;
+  let madnessSaves = existingMadness;
+  let currentPhysicalHealth = existing.currentPhysicalHealth;
+  let currentMentalHealth = existing.currentMentalHealth;
+  let seriousPhysicalInjuries = existing.seriousPhysicalInjuries;
+  let seriousTrauma = existing.seriousTrauma;
+  let status = existing.status;
+
+  if (patch.currentPhysicalHealth != null) {
+    currentPhysicalHealth = patch.currentPhysicalHealth;
+  }
+  if (patch.currentMentalHealth != null) {
+    currentMentalHealth = patch.currentMentalHealth;
+  }
+  if (patch.seriousPhysicalInjuries != null) {
+    seriousPhysicalInjuries = patch.seriousPhysicalInjuries;
+  }
+  if (patch.seriousTrauma != null) {
+    seriousTrauma = patch.seriousTrauma;
+  }
+  if (patch.deathSaves != null) {
+    deathSaves = clampTrack(patch.deathSaves);
+  }
+  if (patch.madnessSaves != null) {
+    madnessSaves = clampTrack(patch.madnessSaves);
+  }
+  if (patch.status != null) {
+    status = patch.status;
+  }
+
+  if (patch.currentPhysicalHealth != null && currentPhysicalHealth > 0) {
+    deathSaves = emptyTrack();
+  }
+  if (patch.currentMentalHealth != null && currentMentalHealth > 0) {
+    madnessSaves = emptyTrack();
+  }
+
+  const mergedForHits: CharacterHealthSnapshot = {
+    ...existing,
+    currentPhysicalHealth,
+    currentMentalHealth,
+    seriousPhysicalInjuries,
+    seriousTrauma,
+    deathSaves,
+    madnessSaves,
+    status,
+  };
+
+  const physicalHits = patch.physicalHitsAtZero ?? 0;
+  if (physicalHits > 0) {
+    if (existing.currentPhysicalHealth !== 0 || currentPhysicalHealth !== 0) {
+      return {
+        ok: false,
+        error: "Physical hits at zero HP only apply while physical HP is 0.",
+      };
+    }
+    if (!inDeathCycle({ ...mergedForHits, deathSaves: existingDeath })) {
+      return {
+        ok: false,
+        error:
+          "A hit at 0 physical HP does not mark a death-roll failure while stable or deceased. Reset the death roll first if starting a new cycle.",
+      };
+    }
+    deathSaves = clampTrack({
+      ...deathSaves,
+      failures: deathSaves.failures + physicalHits,
+    });
+  }
+
+  const mentalHits = patch.mentalHitsAtZero ?? 0;
+  if (mentalHits > 0) {
+    if (existing.currentMentalHealth !== 0 || currentMentalHealth !== 0) {
+      return {
+        ok: false,
+        error: "Mental hits at zero HP only apply while mental HP is 0.",
+      };
+    }
+    if (
+      !inMadnessCycle({
+        ...mergedForHits,
+        madnessSaves: existingMadness,
+      })
+    ) {
+      return {
+        ok: false,
+        error:
+          "A hit at 0 mental HP does not mark a madness-roll failure while composed, deranged, or deceased. Reset the madness roll first if starting a new cycle.",
+      };
+    }
+    madnessSaves = clampTrack({
+      ...madnessSaves,
+      failures: madnessSaves.failures + mentalHits,
+    });
+  }
+
+  if (patch.seriousPhysicalInjuries != null && seriousPhysicalInjuries >= 3) {
+    status = "DECEASED";
+  }
+  if (
+    (patch.deathSaves != null || physicalHits > 0) &&
+    deathSaves.failures >= 3
+  ) {
+    status = "DECEASED";
+  }
+  if (
+    patch.seriousTrauma != null &&
+    seriousTrauma >= 3 &&
+    status !== "DECEASED"
+  ) {
+    status = "DERANGED";
+  }
+  if (
+    (patch.madnessSaves != null || mentalHits > 0) &&
+    madnessSaves.failures >= 3 &&
+    status !== "DECEASED"
+  ) {
+    status = "DERANGED";
+  }
+
+  return {
+    ok: true,
+    health: {
+      ...existing,
+      currentPhysicalHealth,
+      currentMentalHealth,
+      seriousPhysicalInjuries,
+      seriousTrauma,
+      deathSaves,
+      madnessSaves,
+      status,
+    },
+  };
+}

--- a/src/app/lib/applyCharacterHealthPatch.ts
+++ b/src/app/lib/applyCharacterHealthPatch.ts
@@ -1,6 +1,6 @@
 import type { Status } from "@prisma/client";
 
-export type CrisisTrack = {
+type CrisisTrack = {
   successes: number;
   failures: number;
 };

--- a/src/app/lib/constants/inventory.ts
+++ b/src/app/lib/constants/inventory.ts
@@ -1,6 +1,9 @@
 /** Value for itemLocation when the character has the item on them */
 export const ITEM_LOCATION_CARRIED = "carried" as const;
 
+/** In-place stack quantity ceiling on a holding (browse-add may use a lower cap). */
+export const MAX_STACK_QUANTITY = 999;
+
 const VEHICLE_CARGO_LOCATION_PREFIX = "vehicle:" as const;
 const VEHICLE_MOUNTED_LOCATION_PREFIX = "vehicle-mounted:" as const;
 

--- a/src/app/lib/crisisRoll.ts
+++ b/src/app/lib/crisisRoll.ts
@@ -1,9 +1,6 @@
-export const CRISIS_SUCCESS_MIN = 8;
+const CRISIS_SUCCESS_MIN = 8;
 
-export function crisisDicePoolSize(
-  attributeScore: number,
-  penalty: number
-): number {
+function crisisDicePoolSize(attributeScore: number, penalty: number): number {
   return Math.max(1, attributeScore - penalty);
 }
 

--- a/src/app/lib/crisisRoll.ts
+++ b/src/app/lib/crisisRoll.ts
@@ -1,0 +1,31 @@
+export const CRISIS_SUCCESS_MIN = 8;
+
+export function crisisDicePoolSize(
+  attributeScore: number,
+  penalty: number
+): number {
+  return Math.max(1, attributeScore - penalty);
+}
+
+export function deathRollDicePoolSize(
+  resilience: number,
+  stamina: number,
+  seriousPhysicalInjuries: number
+): number {
+  return crisisDicePoolSize(
+    Math.max(resilience, stamina),
+    seriousPhysicalInjuries
+  );
+}
+
+export function madnessRollDicePoolSize(
+  mentality: number,
+  seriousTrauma: number
+): number {
+  return crisisDicePoolSize(mentality, seriousTrauma);
+}
+
+/** Any die 8–10 marks the box a success; otherwise a failure. */
+export function crisisPoolIsSuccess(dice: readonly number[]): boolean {
+  return dice.some((die) => die >= CRISIS_SUCCESS_MIN);
+}

--- a/src/app/lib/types/character.ts
+++ b/src/app/lib/types/character.ts
@@ -133,8 +133,14 @@ export const healthSchema = z.object({
   seriousTrauma: z.number().max(3).default(0),
   deathSaves: z
     .object({
-      successes: z.number().max(3).default(0),
-      failures: z.number().max(3).default(0),
+      successes: z.number().int().min(0).max(3).default(0),
+      failures: z.number().int().min(0).max(3).default(0),
+    })
+    .nullish(),
+  madnessSaves: z
+    .object({
+      successes: z.number().int().min(0).max(3).default(0),
+      failures: z.number().int().min(0).max(3).default(0),
     })
     .nullish(),
   status: z.nativeEnum(Status).default("ALIVE"),

--- a/src/hooks/use-character-stat-updates.ts
+++ b/src/hooks/use-character-stat-updates.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/api/character";
 import type { KeyedMutator } from "swr";
 import { useRef, useCallback } from "react";
+import type { Status } from "@prisma/client";
 
 const DEBOUNCE_MS = 2500;
 
@@ -15,6 +16,11 @@ type HealthPartial = {
   currentMentalHealth?: number;
   seriousPhysicalInjuries?: number;
   seriousTrauma?: number;
+  deathSaves?: { successes: number; failures: number };
+  madnessSaves?: { successes: number; failures: number };
+  status?: Status;
+  physicalHitsAtZero?: number;
+  mentalHitsAtZero?: number;
 };
 
 type ArmourPartial = {
@@ -58,15 +64,20 @@ export function useCharacterStatUpdates(
   const updateHealth = useCallback(
     (partial: HealthPartial) => {
       if (!character) return;
-      const newHealth = { ...character.health, ...partial };
+      const { physicalHitsAtZero, mentalHitsAtZero, ...healthFields } = partial;
+      const newHealth = { ...character.health, ...healthFields };
       const newCharacter = { ...character, health: newHealth };
       void mutate(newCharacter, false);
 
       pendingHealthRef.current = {
+        ...pendingHealthRef.current,
+        ...partial,
         currentPhysicalHealth: newHealth.currentPhysicalHealth,
         currentMentalHealth: newHealth.currentMentalHealth,
         seriousPhysicalInjuries: newHealth.seriousPhysicalInjuries,
         seriousTrauma: newHealth.seriousTrauma,
+        ...(physicalHitsAtZero != null && { physicalHitsAtZero }),
+        ...(mentalHitsAtZero != null && { mentalHitsAtZero }),
       };
 
       if (healthTimeoutRef.current) {

--- a/src/hooks/use-character-stat-updates.ts
+++ b/src/hooks/use-character-stat-updates.ts
@@ -6,7 +6,7 @@ import {
   updateCharacterCombatInfo,
 } from "@/lib/api/character";
 import type { KeyedMutator } from "swr";
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useState } from "react";
 import type { Status } from "@prisma/client";
 
 const DEBOUNCE_MS = 2500;
@@ -27,6 +27,24 @@ type ArmourPartial = {
   armourCurrentHP?: number;
 };
 
+export type CrisisVisibilityHealth = {
+  currentPhysicalHealth: number;
+  currentMentalHealth: number;
+  deathSaves: { successes: number; failures: number } | null | undefined;
+  madnessSaves: { successes: number; failures: number } | null | undefined;
+};
+
+function toCrisisVisibilityHealth(
+  health: CharacterDetail["health"]
+): CrisisVisibilityHealth {
+  return {
+    currentPhysicalHealth: health.currentPhysicalHealth,
+    currentMentalHealth: health.currentMentalHealth,
+    deathSaves: health.deathSaves,
+    madnessSaves: health.madnessSaves,
+  };
+}
+
 export function useCharacterStatUpdates(
   characterId: string,
   character: CharacterDetail | null,
@@ -36,16 +54,30 @@ export function useCharacterStatUpdates(
   const armourTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingHealthRef = useRef<HealthPartial | null>(null);
   const pendingArmourRef = useRef<ArmourPartial | null>(null);
+  const settledCrisisHealthRef = useRef<CrisisVisibilityHealth | null>(
+    character ? toCrisisVisibilityHealth(character.health) : null
+  );
+  const [healthWritePending, setHealthWritePending] = useState(false);
+
+  if (character && !healthWritePending) {
+    settledCrisisHealthRef.current = toCrisisVisibilityHealth(character.health);
+  }
 
   const saveHealth = useCallback(async () => {
     const payload = pendingHealthRef.current;
     pendingHealthRef.current = null;
-    if (!payload || !characterId) return;
+    if (!payload || !characterId) {
+      setHealthWritePending(false);
+      return;
+    }
     try {
       const updated = await updateCharacterHealth(characterId, payload);
+      settledCrisisHealthRef.current = toCrisisVisibilityHealth(updated.health);
       await mutate(updated, false);
     } catch {
       await mutate();
+    } finally {
+      setHealthWritePending(false);
     }
   }, [characterId, mutate]);
 
@@ -64,6 +96,12 @@ export function useCharacterStatUpdates(
   const updateHealth = useCallback(
     (partial: HealthPartial) => {
       if (!character) return;
+      if (!healthWritePending) {
+        settledCrisisHealthRef.current = toCrisisVisibilityHealth(
+          character.health
+        );
+        setHealthWritePending(true);
+      }
       const { physicalHitsAtZero, mentalHitsAtZero, ...healthFields } = partial;
       const newHealth = { ...character.health, ...healthFields };
       const newCharacter = { ...character, health: newHealth };
@@ -88,7 +126,7 @@ export function useCharacterStatUpdates(
         void saveHealth();
       }, DEBOUNCE_MS);
     },
-    [character, mutate, saveHealth]
+    [character, healthWritePending, mutate, saveHealth]
   );
 
   const updateArmour = useCallback(
@@ -119,5 +157,10 @@ export function useCharacterStatUpdates(
     [character, mutate, saveArmour]
   );
 
-  return { updateHealth, updateArmour };
+  return {
+    updateHealth,
+    updateArmour,
+    healthWritePending,
+    settledCrisisHealth: settledCrisisHealthRef.current,
+  };
 }

--- a/src/lib/api/character.ts
+++ b/src/lib/api/character.ts
@@ -13,6 +13,7 @@ import type {
   LevelUpAttributePath,
   LevelUpGeneralSkill,
 } from "@/app/lib/levelUpPaths";
+import type { Status } from "@prisma/client";
 
 type ApiErrorPayload = { message?: string; details?: string };
 export type { LevelUpAttributePath, LevelUpGeneralSkill };
@@ -225,7 +226,10 @@ type HealthUpdateBody = {
   seriousPhysicalInjuries?: number;
   seriousTrauma?: number;
   deathSaves?: { successes: number; failures: number };
-  status?: string;
+  madnessSaves?: { successes: number; failures: number };
+  status?: Status;
+  physicalHitsAtZero?: number;
+  mentalHitsAtZero?: number;
 };
 
 type CombatInfoUpdateBody = {

--- a/src/lib/api/character.ts
+++ b/src/lib/api/character.ts
@@ -6,7 +6,10 @@ import {
   type CharacterNoteEntry,
 } from "@/app/lib/types/character";
 import { walletSchema, type Currency } from "@/app/lib/types/item";
-import type { CharacterCreationRequest } from "@/app/api/characters/schemas";
+import type {
+  CharacterCreationRequest,
+  CharacterEditableUpdateRequest,
+} from "@/app/api/characters/schemas";
 import type { SoldierFavouriteWeaponUpdate } from "@/app/lib/types/path";
 import { getUserSafeApiError } from "@/lib/userSafeError";
 import type {
@@ -23,7 +26,7 @@ export type CharacterCreateBody = CharacterCreationRequest & {
   gameId?: string;
   gameLinkIsPublic?: boolean;
 };
-export type CharacterEditableUpdateBody = CharacterCreationRequest;
+export type CharacterEditableUpdateBody = CharacterEditableUpdateRequest;
 export type CharacterLevelUpBody = {
   healthUpdate: { rolledPhysicalHealth: number; rolledMentalHealth: number };
   pathId: string;

--- a/src/lib/api/characterInventoryMutate.ts
+++ b/src/lib/api/characterInventoryMutate.ts
@@ -34,12 +34,27 @@ export async function patchCharacterInventoryEntryAndMutate(
   characterId: string,
   itemCharacterId: string,
   body: UpdateInventoryEntryBody
-): Promise<InventoryEntry> {
+): Promise<InventoryEntry | null> {
   const updated = await updateCharacterInventoryEntry(
     characterId,
     itemCharacterId,
     body
   );
+  if (updated == null) {
+    await mutate(
+      (current) =>
+        current
+          ? {
+              ...current,
+              inventory: (current.inventory ?? []).filter(
+                (entry) => entry.id !== itemCharacterId
+              ),
+            }
+          : current,
+      { revalidate: true }
+    );
+    return null;
+  }
   await mutate(
     (current) =>
       current ? mergeInventoryEntryIntoCharacter(current, updated) : current,

--- a/src/lib/api/items.ts
+++ b/src/lib/api/items.ts
@@ -91,13 +91,15 @@ export type UpdateInventoryEntryBody =
   | { action: "setLocation"; itemLocation: string }
   | { action: "setCurrentUses"; currentUses: number }
   | { action: "decrementUse" }
-  | { action: "setStatus"; status: ItemStatus };
+  | { action: "setStatus"; status: ItemStatus }
+  | { action: "setQuantity"; quantity: number }
+  | { action: "setCustomName"; customName: string | null };
 
 export async function updateCharacterInventoryEntry(
   characterId: string,
   itemCharacterId: string,
   body: UpdateInventoryEntryBody
-): Promise<InventoryEntry> {
+): Promise<InventoryEntry | null> {
   const response = await fetch(
     `/api/characters/${encodeURIComponent(characterId)}/inventory/${encodeURIComponent(itemCharacterId)}`,
     {
@@ -109,19 +111,23 @@ export async function updateCharacterInventoryEntry(
   );
 
   if (!response.ok) {
-    let body: ApiErrorPayload | undefined;
+    let errorBody: ApiErrorPayload | undefined;
     try {
-      body = (await response.json()) as ApiErrorPayload;
+      errorBody = (await response.json()) as ApiErrorPayload;
     } catch {
       // ignore
     }
     throw new Error(
       getUserSafeApiError(
         response.status,
-        body,
+        errorBody,
         "Failed to update inventory entry"
       )
     );
+  }
+
+  if (response.status === 204) {
+    return null;
   }
 
   const json = await response.json();

--- a/test/api/characters/[id]/health/route.test.ts
+++ b/test/api/characters/[id]/health/route.test.ts
@@ -17,28 +17,38 @@ vi.mock("@/app/api/characters/[id]/health/schema", () => ({
   healthUpdateSchema: { safeParse: safeParseMock },
 }));
 
+function baseHealth(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    maxPhysicalHealth: 10,
+    maxMentalHealth: 10,
+    currentPhysicalHealth: 8,
+    currentMentalHealth: 8,
+    seriousPhysicalInjuries: 0,
+    seriousTrauma: 0,
+    deathSaves: { successes: 0, failures: 0 },
+    madnessSaves: { successes: 0, failures: 0 },
+    status: "ALIVE",
+    ...overrides,
+  };
+}
+
 describe("/api/characters/[id]/health PATCH", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    characterBelongsToUserMock.mockResolvedValue(true);
+    updateCharacterMock.mockResolvedValue({ id: "char-1" });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth(),
+    });
   });
 
   it("returns 400 when parsed current physical health exceeds max", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { currentPhysicalHealth: 99 },
       error: undefined,
-    });
-    getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
-        currentPhysicalHealth: 8,
-        currentMentalHealth: 8,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
-        deathSaves: { successes: 0, failures: 0 },
-        status: "ALIVE",
-      },
     });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
@@ -50,7 +60,6 @@ describe("/api/characters/[id]/health PATCH", () => {
   });
 
   it("returns 404 when character does not exist", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({ data: {}, error: undefined });
     getCharacterMock.mockResolvedValue(null);
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
@@ -63,24 +72,10 @@ describe("/api/characters/[id]/health PATCH", () => {
   });
 
   it("returns 200 on success", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { status: "ALIVE" },
       error: undefined,
     });
-    getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
-        currentPhysicalHealth: 8,
-        currentMentalHealth: 8,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
-        deathSaves: { successes: 0, failures: 0 },
-        status: "ALIVE",
-      },
-    });
-    updateCharacterMock.mockResolvedValue({ id: "char-1" });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
       PATCH,
@@ -90,26 +85,148 @@ describe("/api/characters/[id]/health PATCH", () => {
     expect(response.status).toBe(200);
   });
 
+  it("sets status without rewriting death-roll boxes", async () => {
+    safeParseMock.mockReturnValue({
+      data: { status: "DECEASED" },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 1, failures: 2 },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        status: "DECEASED",
+        deathSaves: { successes: 1, failures: 2 },
+      }),
+    });
+  });
+
+  it("clears the death-roll track when physical HP rises above 0", async () => {
+    safeParseMock.mockReturnValue({
+      data: { currentPhysicalHealth: 2 },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 2, failures: 1 },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        currentPhysicalHealth: 2,
+        deathSaves: { successes: 0, failures: 0 },
+      }),
+    });
+  });
+
+  it("clears the madness-roll track when mental HP rises above 0", async () => {
+    safeParseMock.mockReturnValue({
+      data: { currentMentalHealth: 3 },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 2, failures: 1 },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        currentMentalHealth: 3,
+        madnessSaves: { successes: 0, failures: 0 },
+      }),
+    });
+  });
+
+  it("marks a death-roll failure for physicalHitsAtZero while in-cycle", async () => {
+    safeParseMock.mockReturnValue({
+      data: { physicalHitsAtZero: 1 },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 1, failures: 1 },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 1, failures: 2 },
+      }),
+    });
+  });
+
+  it("marks a madness-roll failure for mentalHitsAtZero while in-cycle", async () => {
+    safeParseMock.mockReturnValue({
+      data: { mentalHitsAtZero: 1 },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 0, failures: 1 },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 0, failures: 2 },
+      }),
+    });
+  });
+
   it("persists DECEASED when death-roll failures reach 3", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { deathSaves: { successes: 0, failures: 3 } },
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
+      id: "char-1",
+      health: baseHealth({
         currentPhysicalHealth: 0,
-        currentMentalHealth: 8,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
         deathSaves: { successes: 1, failures: 2 },
-        madnessSaves: { successes: 0, failures: 0 },
-        status: "ALIVE",
-      },
+      }),
     });
-    updateCharacterMock.mockResolvedValue({ id: "char-1" });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
       PATCH,
@@ -126,25 +243,17 @@ describe("/api/characters/[id]/health PATCH", () => {
   });
 
   it("persists DERANGED when madness-roll failures reach 3", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { madnessSaves: { successes: 0, failures: 3 } },
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
-        currentPhysicalHealth: 8,
+      id: "char-1",
+      health: baseHealth({
         currentMentalHealth: 0,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
-        deathSaves: { successes: 0, failures: 0 },
         madnessSaves: { successes: 1, failures: 2 },
-        status: "ALIVE",
-      },
+      }),
     });
-    updateCharacterMock.mockResolvedValue({ id: "char-1" });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
       PATCH,
@@ -160,24 +269,67 @@ describe("/api/characters/[id]/health PATCH", () => {
     });
   });
 
+  it("treats missing madnessSaves on the stored character as an empty track", async () => {
+    safeParseMock.mockReturnValue({
+      data: { madnessSaves: { successes: 0, failures: 1 } },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentMentalHealth: 0,
+        madnessSaves: undefined,
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        madnessSaves: { successes: 0, failures: 1 },
+      }),
+    });
+  });
+
   it("returns 400 when death-roll boxes are edited while deceased", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { deathSaves: { successes: 0, failures: 2 } },
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
+      id: "char-1",
+      health: baseHealth({
         currentPhysicalHealth: 0,
-        currentMentalHealth: 8,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
         deathSaves: { successes: 0, failures: 3 },
-        madnessSaves: { successes: 0, failures: 0 },
         status: "DECEASED",
-      },
+      }),
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(400);
+    expect(updateCharacterMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when madness-roll boxes are edited while deranged", async () => {
+    safeParseMock.mockReturnValue({
+      data: { madnessSaves: { successes: 1, failures: 2 } },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      id: "char-1",
+      health: baseHealth({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 0, failures: 3 },
+        status: "DERANGED",
+      }),
     });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
@@ -190,23 +342,16 @@ describe("/api/characters/[id]/health PATCH", () => {
   });
 
   it("returns 400 for a physical hit at 0 while stable", async () => {
-    characterBelongsToUserMock.mockResolvedValue(true);
     safeParseMock.mockReturnValue({
       data: { physicalHitsAtZero: 1 },
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: {
-        maxPhysicalHealth: 10,
-        maxMentalHealth: 10,
+      id: "char-1",
+      health: baseHealth({
         currentPhysicalHealth: 0,
-        currentMentalHealth: 8,
-        seriousPhysicalInjuries: 0,
-        seriousTrauma: 0,
         deathSaves: { successes: 3, failures: 0 },
-        madnessSaves: { successes: 0, failures: 0 },
-        status: "ALIVE",
-      },
+      }),
     });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(

--- a/test/api/characters/[id]/health/route.test.ts
+++ b/test/api/characters/[id]/health/route.test.ts
@@ -29,7 +29,16 @@ describe("/api/characters/[id]/health PATCH", () => {
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: { maxPhysicalHealth: 10, maxMentalHealth: 10 },
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 8,
+        currentMentalHealth: 8,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 0, failures: 0 },
+        status: "ALIVE",
+      },
     });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
     const response = await invokeRoute(
@@ -60,7 +69,16 @@ describe("/api/characters/[id]/health PATCH", () => {
       error: undefined,
     });
     getCharacterMock.mockResolvedValue({
-      health: { maxPhysicalHealth: 10, maxMentalHealth: 10, status: "ALIVE" },
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 8,
+        currentMentalHealth: 8,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 0, failures: 0 },
+        status: "ALIVE",
+      },
     });
     updateCharacterMock.mockResolvedValue({ id: "char-1" });
     const { PATCH } = await import("@/app/api/characters/[id]/health/route");
@@ -70,5 +88,133 @@ describe("/api/characters/[id]/health PATCH", () => {
       makeParams({ id: "char-1" })
     );
     expect(response.status).toBe(200);
+  });
+
+  it("persists DECEASED when death-roll failures reach 3", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    safeParseMock.mockReturnValue({
+      data: { deathSaves: { successes: 0, failures: 3 } },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 0,
+        currentMentalHealth: 8,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 1, failures: 2 },
+        madnessSaves: { successes: 0, failures: 0 },
+        status: "ALIVE",
+      },
+    });
+    updateCharacterMock.mockResolvedValue({ id: "char-1" });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        status: "DECEASED",
+        deathSaves: { successes: 0, failures: 3 },
+      }),
+    });
+  });
+
+  it("persists DERANGED when madness-roll failures reach 3", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    safeParseMock.mockReturnValue({
+      data: { madnessSaves: { successes: 0, failures: 3 } },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 8,
+        currentMentalHealth: 0,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 0, failures: 0 },
+        madnessSaves: { successes: 1, failures: 2 },
+        status: "ALIVE",
+      },
+    });
+    updateCharacterMock.mockResolvedValue({ id: "char-1" });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(updateCharacterMock).toHaveBeenCalledWith("char-1", {
+      health: expect.objectContaining({
+        status: "DERANGED",
+        madnessSaves: { successes: 0, failures: 3 },
+      }),
+    });
+  });
+
+  it("returns 400 when death-roll boxes are edited while deceased", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    safeParseMock.mockReturnValue({
+      data: { deathSaves: { successes: 0, failures: 2 } },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 0,
+        currentMentalHealth: 8,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 0, failures: 3 },
+        madnessSaves: { successes: 0, failures: 0 },
+        status: "DECEASED",
+      },
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(400);
+    expect(updateCharacterMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a physical hit at 0 while stable", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    safeParseMock.mockReturnValue({
+      data: { physicalHitsAtZero: 1 },
+      error: undefined,
+    });
+    getCharacterMock.mockResolvedValue({
+      health: {
+        maxPhysicalHealth: 10,
+        maxMentalHealth: 10,
+        currentPhysicalHealth: 0,
+        currentMentalHealth: 8,
+        seriousPhysicalInjuries: 0,
+        seriousTrauma: 0,
+        deathSaves: { successes: 3, failures: 0 },
+        madnessSaves: { successes: 0, failures: 0 },
+        status: "ALIVE",
+      },
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/health/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({}),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(400);
+    expect(updateCharacterMock).not.toHaveBeenCalled();
   });
 });

--- a/test/api/characters/[id]/inventory/[itemCharacterId]/route.test.ts
+++ b/test/api/characters/[id]/inventory/[itemCharacterId]/route.test.ts
@@ -167,4 +167,100 @@ describe("/api/characters/[id]/inventory/[itemCharacterId] PATCH", () => {
       data: { itemLocation: "locker" },
     });
   });
+
+  it("sets stack quantity on the holding", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    getCharacterInventoryMock.mockReset();
+    getCharacterInventoryMock
+      .mockResolvedValueOnce([{ id: "ic-1", quantity: 3, equipSlots: [] }])
+      .mockResolvedValueOnce([{ id: "ic-1", quantity: 7, equipSlots: [] }]);
+    updateItemCharacterMock.mockResolvedValue({});
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/inventory/[itemCharacterId]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({ action: "setQuantity", quantity: 7 }, "user-1"),
+      makeParams({ id: "char-1", itemCharacterId: "ic-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(updateItemCharacterMock).toHaveBeenCalledWith("ic-1", {
+      quantity: 7,
+    });
+  });
+
+  it("deletes the holding when stack quantity is set to 0", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    getCharacterInventoryMock.mockReset();
+    getCharacterInventoryMock.mockResolvedValue([
+      { id: "ic-1", quantity: 3, equipSlots: [] },
+    ]);
+    deleteItemCharacterMock.mockResolvedValue(undefined);
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/inventory/[itemCharacterId]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({ action: "setQuantity", quantity: 0 }, "user-1"),
+      makeParams({ id: "char-1", itemCharacterId: "ic-1" })
+    );
+    expect(response.status).toBe(204);
+    expect(deleteItemCharacterMock).toHaveBeenCalledWith("ic-1");
+  });
+
+  it("rejects stack quantity above 999", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    getCharacterInventoryMock.mockReset();
+    getCharacterInventoryMock.mockResolvedValue([
+      { id: "ic-1", quantity: 3, equipSlots: [] },
+    ]);
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/inventory/[itemCharacterId]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({ action: "setQuantity", quantity: 1000 }, "user-1"),
+      makeParams({ id: "char-1", itemCharacterId: "ic-1" })
+    );
+    expect(response.status).toBe(400);
+    expect(updateItemCharacterMock).not.toHaveBeenCalled();
+  });
+
+  it("sets and clears a nickname on the holding", async () => {
+    characterBelongsToUserMock.mockResolvedValue(true);
+    getCharacterInventoryMock.mockReset();
+    getCharacterInventoryMock
+      .mockResolvedValueOnce([{ id: "ic-1", quantity: 1, equipSlots: [] }])
+      .mockResolvedValueOnce([
+        { id: "ic-1", quantity: 1, equipSlots: [], customName: "Lucky blade" },
+      ]);
+    updateItemCharacterMock.mockResolvedValue({});
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/inventory/[itemCharacterId]/route");
+    const setResponse = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        { action: "setCustomName", customName: "Lucky blade" },
+        "user-1"
+      ),
+      makeParams({ id: "char-1", itemCharacterId: "ic-1" })
+    );
+    expect(setResponse.status).toBe(200);
+    expect(updateItemCharacterMock).toHaveBeenCalledWith("ic-1", {
+      customName: "Lucky blade",
+    });
+
+    getCharacterInventoryMock
+      .mockResolvedValueOnce([{ id: "ic-1", quantity: 1, equipSlots: [] }])
+      .mockResolvedValueOnce([{ id: "ic-1", quantity: 1, equipSlots: [] }]);
+    const clearResponse = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        { action: "setCustomName", customName: "  " },
+        "user-1"
+      ),
+      makeParams({ id: "char-1", itemCharacterId: "ic-1" })
+    );
+    expect(clearResponse.status).toBe(200);
+    expect(updateItemCharacterMock).toHaveBeenCalledWith("ic-1", {
+      customName: null,
+    });
+  });
 });

--- a/test/api/characters/[id]/route.test.ts
+++ b/test/api/characters/[id]/route.test.ts
@@ -10,6 +10,17 @@ import { CharacterDeletionTransactionError } from "@/app/api/shared/errors";
 const getCharacterMock = vi.fn();
 const deleteCharacterMock = vi.fn();
 const characterBelongsToUserMock = vi.fn();
+const getPathMock = vi.fn();
+const getAllFeaturesAvailableForPathAndRankMock = vi.fn();
+const pathCharacterUpdateMock = vi.fn();
+const pathCharacterDeleteMock = vi.fn();
+const pathCharacterCreateMock = vi.fn();
+const pathCharacterDeleteManyMock = vi.fn();
+const characterCurrencyDeleteManyMock = vi.fn();
+const characterCurrencyCreateManyMock = vi.fn();
+const featureCharacterDeleteManyMock = vi.fn();
+const featureCharacterCreateManyMock = vi.fn();
+const characterUpdateMock = vi.fn();
 
 vi.mock("@/app/lib/prisma/character", () => ({
   getCharacter: getCharacterMock,
@@ -18,6 +29,40 @@ vi.mock("@/app/lib/prisma/character", () => ({
 
 vi.mock("@/app/lib/prisma/characterUser", () => ({
   characterBelongsToUser: characterBelongsToUserMock,
+}));
+
+vi.mock("@/app/lib/prisma/path", () => ({
+  getPath: getPathMock,
+}));
+
+vi.mock("@/app/lib/prisma/feature", () => ({
+  getAllFeaturesAvailableForPathAndRank:
+    getAllFeaturesAvailableForPathAndRankMock,
+}));
+
+vi.mock("@/app/lib/prisma/client", () => ({
+  prisma: {
+    $transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        characterCurrency: {
+          deleteMany: characterCurrencyDeleteManyMock,
+          createMany: characterCurrencyCreateManyMock,
+        },
+        pathCharacter: {
+          update: pathCharacterUpdateMock,
+          delete: pathCharacterDeleteMock,
+          create: pathCharacterCreateMock,
+          deleteMany: pathCharacterDeleteManyMock,
+        },
+        featureCharacter: {
+          deleteMany: featureCharacterDeleteManyMock,
+          createMany: featureCharacterCreateManyMock,
+        },
+        character: {
+          update: characterUpdateMock,
+        },
+      }),
+  },
 }));
 
 describe("/api/characters/[id] handlers", () => {
@@ -117,5 +162,188 @@ describe("/api/characters/[id] handlers", () => {
       makeParams({ id: "char-1" })
     );
     expect(response.status).toBe(204);
+  });
+});
+
+const baseAttributes = {
+  intelligence: { investigation: 2, memory: 2, deduction: 2 },
+  wisdom: { sense: 2, perception: 2, insight: 2 },
+  personality: { persuasion: 2, deception: 2, mentality: 2 },
+  strength: { athletics: 2, resilience: 2, bruteForce: 2 },
+  dexterity: { manual: 2, stealth: 2, agility: 2 },
+  constitution: { resistanceInternal: 2, resistanceExternal: 2, stamina: 2 },
+};
+
+const baseGeneralSkills = {
+  mechanics: 0,
+  software: 0,
+  generalKnowledge: 0,
+  history: 0,
+  driving: 0,
+  acrobatics: 0,
+  aim: 0,
+  melee: 0,
+  GRID: 0,
+  research: 0,
+  medicine: 0,
+  science: 0,
+  survival: 0,
+  streetwise: 0,
+  performance: 0,
+  manipulationNegotiation: 0,
+};
+
+function makeUpdateBody(pathId = "path-soldier") {
+  return {
+    generalInformation: {
+      name: "Ada",
+      surname: "Lovelace",
+      age: 25,
+      religion: "ATHEIST",
+      profession: "Engineer",
+      race: "HUMAN",
+      birthplace: "London",
+      level: 1,
+      height: 170,
+      weight: 70,
+    },
+    health: {
+      rolledPhysicalHealth: 10,
+      rolledMentalHealth: 10,
+      seriousPhysicalInjuries: 0,
+      seriousTrauma: 0,
+      status: "ALIVE",
+    },
+    combatInformation: {
+      armourMod: 0,
+      armourMaxHP: 0,
+      armourCurrentHP: 0,
+      throwAttackMod: 0,
+    },
+    innateAttributes: baseAttributes,
+    learnedSkills: {
+      generalSkills: baseGeneralSkills,
+      specialSkills: [],
+    },
+    wallet: [],
+    path: { pathId, rank: 2 },
+    initialFeatures: [],
+  };
+}
+
+function makeExistingCharacter(
+  paths: Array<{
+    id: string;
+    name: string;
+    rank: number;
+    pathCharacterId: string;
+    favouriteWeaponItemId?: string | null;
+  }>
+) {
+  return {
+    id: "char-1",
+    health: {
+      currentPhysicalHealth: 4,
+      currentMentalHealth: 5,
+      maxPhysicalHealth: 16,
+      maxMentalHealth: 16,
+      deathSaves: { successes: 2, failures: 1 },
+      madnessSaves: { successes: 0, failures: 2 },
+      status: "ALIVE",
+    },
+    combatInformation: { reactionsRemaining: 1 },
+    paths,
+    features: [],
+  };
+}
+
+describe("/api/characters/[id] PATCH", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    characterBelongsToUserMock.mockResolvedValue(true);
+    getPathMock.mockResolvedValue({ id: "path-soldier", name: "SOLDIER" });
+    getAllFeaturesAvailableForPathAndRankMock.mockResolvedValue([]);
+    getCharacterMock.mockResolvedValue(
+      makeExistingCharacter([
+        {
+          id: "path-soldier",
+          name: "SOLDIER",
+          rank: 2,
+          pathCharacterId: "pc-soldier",
+          favouriteWeaponItemId: "weapon-1",
+        },
+        {
+          id: "path-medic",
+          name: "MEDIC",
+          rank: 1,
+          pathCharacterId: "pc-medic",
+        },
+      ])
+    );
+  });
+
+  it("keeps current HP, crisis tracks, and reactions instead of full-healing", async () => {
+    const { PATCH } = await import("@/app/api/characters/[id]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(makeUpdateBody()),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(characterUpdateMock).toHaveBeenCalled();
+    const updateData = characterUpdateMock.mock.calls[0][0].data;
+    expect(updateData.health).toMatchObject({
+      currentPhysicalHealth: 4,
+      currentMentalHealth: 5,
+      deathSaves: { successes: 2, failures: 1 },
+      madnessSaves: { successes: 0, failures: 2 },
+    });
+    expect(updateData.combatInformation.reactionsRemaining).toBe(1);
+  });
+
+  it("updates an existing path in place and does not delete other paths", async () => {
+    const { PATCH } = await import("@/app/api/characters/[id]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(makeUpdateBody("path-soldier")),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(pathCharacterUpdateMock).toHaveBeenCalledWith({
+      where: { id: "pc-soldier" },
+      data: { rank: 2 },
+    });
+    expect(pathCharacterUpdateMock.mock.calls[0][0].data).not.toHaveProperty(
+      "favouriteWeapon"
+    );
+    expect(pathCharacterDeleteMock).not.toHaveBeenCalled();
+    expect(pathCharacterCreateMock).not.toHaveBeenCalled();
+    expect(pathCharacterDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("replaces only the previous primary path when the form path is new", async () => {
+    getPathMock.mockResolvedValue({
+      id: "path-techno",
+      name: "TECHNO_CRAFTER",
+    });
+    const { PATCH } = await import("@/app/api/characters/[id]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(makeUpdateBody("path-techno")),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(pathCharacterDeleteMock).toHaveBeenCalledWith({
+      where: { id: "pc-soldier" },
+    });
+    expect(pathCharacterCreateMock).toHaveBeenCalledWith({
+      data: {
+        characterId: "char-1",
+        pathId: "path-techno",
+        rank: 2,
+      },
+    });
+    expect(pathCharacterDeleteManyMock).not.toHaveBeenCalled();
+    expect(pathCharacterUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/test/api/characters/[id]/route.test.ts
+++ b/test/api/characters/[id]/route.test.ts
@@ -193,7 +193,10 @@ const baseGeneralSkills = {
   manipulationNegotiation: 0,
 };
 
-function makeUpdateBody(pathId = "path-soldier") {
+function makeUpdateBody(
+  pathId = "path-soldier",
+  extras: { primaryPathCharacterId?: string; rank?: number } = {}
+) {
   return {
     generalInformation: {
       name: "Ada",
@@ -226,7 +229,10 @@ function makeUpdateBody(pathId = "path-soldier") {
       specialSkills: [],
     },
     wallet: [],
-    path: { pathId, rank: 2 },
+    path: { pathId, rank: extras.rank ?? 2 },
+    ...(extras.primaryPathCharacterId != null
+      ? { primaryPathCharacterId: extras.primaryPathCharacterId }
+      : {}),
     initialFeatures: [],
   };
 }
@@ -329,7 +335,11 @@ describe("/api/characters/[id] PATCH", () => {
     const { PATCH } = await import("@/app/api/characters/[id]/route");
     const response = await invokeRoute(
       PATCH,
-      makeAuthedRequest(makeUpdateBody("path-techno")),
+      makeAuthedRequest(
+        makeUpdateBody("path-techno", {
+          primaryPathCharacterId: "pc-soldier",
+        })
+      ),
       makeParams({ id: "char-1" })
     );
     expect(response.status).toBe(200);
@@ -344,6 +354,91 @@ describe("/api/characters/[id] PATCH", () => {
       },
     });
     expect(pathCharacterDeleteManyMock).not.toHaveBeenCalled();
+    expect(pathCharacterUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("uses primaryPathCharacterId from form open even when ranks have changed", async () => {
+    getPathMock.mockResolvedValue({
+      id: "path-techno",
+      name: "TECHNO_CRAFTER",
+    });
+    getCharacterMock.mockResolvedValue(
+      makeExistingCharacter([
+        {
+          id: "path-medic",
+          name: "MEDIC",
+          rank: 3,
+          pathCharacterId: "pc-medic",
+        },
+        {
+          id: "path-soldier",
+          name: "SOLDIER",
+          rank: 1,
+          pathCharacterId: "pc-soldier",
+          favouriteWeaponItemId: "weapon-1",
+        },
+      ])
+    );
+    const { PATCH } = await import("@/app/api/characters/[id]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        makeUpdateBody("path-techno", {
+          primaryPathCharacterId: "pc-soldier",
+          rank: 1,
+        })
+      ),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(pathCharacterDeleteMock).toHaveBeenCalledWith({
+      where: { id: "pc-soldier" },
+    });
+    expect(pathCharacterDeleteMock).not.toHaveBeenCalledWith({
+      where: { id: "pc-medic" },
+    });
+  });
+
+  it("keeps the Soldier favourite weapon when a secondary Soldier path remains", async () => {
+    getPathMock.mockResolvedValue({
+      id: "path-techno",
+      name: "TECHNO_CRAFTER",
+    });
+    getCharacterMock.mockResolvedValue(
+      makeExistingCharacter([
+        {
+          id: "path-medic",
+          name: "MEDIC",
+          rank: 2,
+          pathCharacterId: "pc-medic",
+        },
+        {
+          id: "path-soldier",
+          name: "SOLDIER",
+          rank: 1,
+          pathCharacterId: "pc-soldier",
+          favouriteWeaponItemId: "weapon-1",
+        },
+      ])
+    );
+    const { PATCH } = await import("@/app/api/characters/[id]/route");
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        makeUpdateBody("path-techno", {
+          primaryPathCharacterId: "pc-medic",
+          rank: 1,
+        })
+      ),
+      makeParams({ id: "char-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(pathCharacterDeleteMock).toHaveBeenCalledWith({
+      where: { id: "pc-medic" },
+    });
+    expect(pathCharacterDeleteMock).not.toHaveBeenCalledWith({
+      where: { id: "pc-soldier" },
+    });
     expect(pathCharacterUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/test/api/characters/[id]/vehicles/[vehicleCharacterId]/route.test.ts
+++ b/test/api/characters/[id]/vehicles/[vehicleCharacterId]/route.test.ts
@@ -95,6 +95,71 @@ describe("/api/characters/[id]/vehicles/[vehicleCharacterId] handlers", () => {
     expect(clearVehicleRidersMock).toHaveBeenCalledWith("vc-1");
   });
 
+  it("PATCH sets a vehicle nickname and clears it when blank", async () => {
+    belongsMock.mockResolvedValue(true);
+    getCharacterVehicleRecordMock.mockResolvedValue({
+      id: "vc-1",
+      characterId: "char-1",
+      currentHp: 10,
+    });
+    canVehicleBeRiddenMock.mockReturnValue(true);
+    getHydratedVehicleCharacterMock.mockResolvedValue({ id: "vc-1" });
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/vehicles/[vehicleCharacterId]/route");
+
+    const setResponse = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        { action: "setCustomName", customName: "Red hopper" },
+        "user-1"
+      ),
+      makeParams({ id: "char-1", vehicleCharacterId: "vc-1" })
+    );
+    expect(setResponse.status).toBe(200);
+    expect(updateVehicleCharacterMock).toHaveBeenCalledWith("vc-1", {
+      customName: "Red hopper",
+    });
+
+    const clearResponse = await invokeRoute(
+      PATCH,
+      makeAuthedRequest(
+        { action: "setCustomName", customName: "  " },
+        "user-1"
+      ),
+      makeParams({ id: "char-1", vehicleCharacterId: "vc-1" })
+    );
+    expect(clearResponse.status).toBe(200);
+    expect(updateVehicleCharacterMock).toHaveBeenLastCalledWith("vc-1", {
+      customName: null,
+    });
+  });
+
+  it("PATCH sets max HP bonus on the holding", async () => {
+    belongsMock.mockResolvedValue(true);
+    getCharacterVehicleRecordMock.mockResolvedValue({
+      id: "vc-1",
+      characterId: "char-1",
+      currentHp: 10,
+    });
+    canVehicleBeRiddenMock.mockReturnValue(true);
+    getHydratedVehicleCharacterMock.mockResolvedValue({
+      id: "vc-1",
+      maxHpBonus: 4,
+    });
+    const { PATCH } =
+      await import("@/app/api/characters/[id]/vehicles/[vehicleCharacterId]/route");
+
+    const response = await invokeRoute(
+      PATCH,
+      makeAuthedRequest({ action: "setMaxHpBonus", maxHpBonus: 4 }, "user-1"),
+      makeParams({ id: "char-1", vehicleCharacterId: "vc-1" })
+    );
+    expect(response.status).toBe(200);
+    expect(updateVehicleCharacterMock).toHaveBeenCalledWith("vc-1", {
+      maxHpBonus: 4,
+    });
+  });
+
   it("PATCH returns 400 on invalid body", async () => {
     belongsMock.mockResolvedValue(true);
     const { PATCH } =

--- a/test/api/characters/parsing.test.ts
+++ b/test/api/characters/parsing.test.ts
@@ -156,6 +156,7 @@ describe("computeCharacterRequestData", () => {
         maxMentalHealth: 16,
         currentMentalHealth: 16,
         deathSaves: { successes: 0, failures: 0 },
+        madnessSaves: { successes: 0, failures: 0 },
       });
       expect(result.combatInformation).toMatchObject({
         initiativeMod: 4,
@@ -270,6 +271,77 @@ describe("computeCharacterRequestData", () => {
       });
       const result = computeCharacterRequestData(input, true);
       expect(result.learnedSkills).toBeDefined();
+    });
+
+    it("keeps current HP, crisis tracks, and reactions from the level-up body", () => {
+      const base = makeLevelUpBody();
+      const result = computeCharacterRequestData(
+        {
+          ...base,
+          health: {
+            ...base.health,
+            currentPhysicalHealth: 4,
+            currentMentalHealth: 7,
+            deathSaves: { successes: 2, failures: 1 },
+            madnessSaves: { successes: 1, failures: 2 },
+          },
+          combatInformation: {
+            ...base.combatInformation,
+            reactionsRemaining: 1,
+          },
+        },
+        true
+      );
+      expect(result.health).toMatchObject({
+        currentPhysicalHealth: 4,
+        currentMentalHealth: 7,
+        deathSaves: { successes: 2, failures: 1 },
+        madnessSaves: { successes: 1, failures: 2 },
+      });
+      expect(result.combatInformation.reactionsRemaining).toBe(1);
+    });
+  });
+
+  describe("preservePlayState (character update)", () => {
+    it("keeps current HP, crisis tracks, and reactions instead of full-healing", () => {
+      const input = makeCharacterCreationRequest();
+      const result = computeCharacterRequestData(input, false, {
+        preservePlayState: {
+          currentPhysicalHealth: 4,
+          currentMentalHealth: 5,
+          deathSaves: { successes: 2, failures: 1 },
+          madnessSaves: { successes: 0, failures: 2 },
+          reactionsRemaining: 1,
+        },
+      });
+      expect(result.health).toMatchObject({
+        currentPhysicalHealth: 4,
+        currentMentalHealth: 5,
+        maxPhysicalHealth: 16,
+        deathSaves: { successes: 2, failures: 1 },
+        madnessSaves: { successes: 0, failures: 2 },
+      });
+      expect(result.combatInformation.reactionsRemaining).toBe(1);
+    });
+
+    it("clamps current HP and reactions down when caps drop", () => {
+      const input = makeCharacterCreationRequest();
+      const result = computeCharacterRequestData(input, false, {
+        preservePlayState: {
+          currentPhysicalHealth: 20,
+          currentMentalHealth: 20,
+          deathSaves: { successes: 1, failures: 0 },
+          madnessSaves: { successes: 0, failures: 1 },
+          reactionsRemaining: 3,
+        },
+      });
+      expect(result.health.currentPhysicalHealth).toBe(16);
+      expect(result.health.currentMentalHealth).toBe(16);
+      expect(result.health.deathSaves).toEqual({
+        successes: 1,
+        failures: 0,
+      });
+      expect(result.combatInformation.reactionsRemaining).toBe(1);
     });
   });
 

--- a/test/api/characters/schemas.test.ts
+++ b/test/api/characters/schemas.test.ts
@@ -117,3 +117,18 @@ describe("characterCreationRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("characterEditableUpdateSchema", () => {
+  it("accepts primaryPathCharacterId from form open", async () => {
+    const { characterEditableUpdateSchema } =
+      await import("@/app/api/characters/schemas");
+    const result = characterEditableUpdateSchema.safeParse({
+      ...makeCharacterCreationRequest(),
+      primaryPathCharacterId: "pc-primary-1",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.primaryPathCharacterId).toBe("pc-primary-1");
+    }
+  });
+});

--- a/test/app/lib/applyCharacterHealthPatch.test.ts
+++ b/test/app/lib/applyCharacterHealthPatch.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { applyCharacterHealthPatch } from "@/app/lib/applyCharacterHealthPatch";
+import type { CharacterHealthSnapshot } from "@/app/lib/applyCharacterHealthPatch";
+
+function health(
+  overrides: Partial<CharacterHealthSnapshot> = {}
+): CharacterHealthSnapshot {
+  return {
+    currentPhysicalHealth: 8,
+    currentMentalHealth: 8,
+    maxPhysicalHealth: 10,
+    maxMentalHealth: 10,
+    seriousPhysicalInjuries: 0,
+    seriousTrauma: 0,
+    deathSaves: { successes: 0, failures: 0 },
+    madnessSaves: { successes: 0, failures: 0 },
+    status: "ALIVE",
+    ...overrides,
+  };
+}
+
+describe("applyCharacterHealthPatch", () => {
+  it("sets status from the patch without rewriting death-roll boxes", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 1, failures: 2 },
+      }),
+      { status: "DECEASED" }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.status).toBe("DECEASED");
+    expect(result.health.deathSaves).toEqual({ successes: 1, failures: 2 });
+  });
+
+  it("does not auto-revive when death-roll failures drop below 3", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        status: "DECEASED",
+        deathSaves: { successes: 0, failures: 3 },
+      }),
+      { deathSaves: { successes: 0, failures: 2 } }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("clears the death-roll track when physical HP rises above 0", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 2, failures: 1 },
+      }),
+      { currentPhysicalHealth: 1 }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.deathSaves).toEqual({ successes: 0, failures: 0 });
+    expect(result.health.status).toBe("ALIVE");
+  });
+
+  it("marks a death-roll failure for a hit while in-cycle at 0 physical HP", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 1, failures: 1 },
+      }),
+      { physicalHitsAtZero: 1 }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.deathSaves.failures).toBe(2);
+    expect(result.health.currentPhysicalHealth).toBe(0);
+  });
+
+  it("does not mark a failure for a hit while stable", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        deathSaves: { successes: 3, failures: 1 },
+      }),
+      { physicalHitsAtZero: 1 }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("sets DECEASED when death-roll failures reach 3", () => {
+    const result = applyCharacterHealthPatch(
+      health({ currentPhysicalHealth: 0 }),
+      { deathSaves: { successes: 1, failures: 3 } }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.status).toBe("DECEASED");
+  });
+
+  it("sets DECEASED when serious physical injuries reach 3", () => {
+    const result = applyCharacterHealthPatch(health(), {
+      seriousPhysicalInjuries: 3,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.status).toBe("DECEASED");
+  });
+
+  it("clears the madness-roll track when mental HP rises above 0", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 2, failures: 1 },
+      }),
+      { currentMentalHealth: 1 }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.madnessSaves).toEqual({ successes: 0, failures: 0 });
+  });
+
+  it("marks a madness-roll failure for a hit while in-cycle at 0 mental HP", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentMentalHealth: 0,
+        madnessSaves: { successes: 1, failures: 1 },
+      }),
+      { mentalHitsAtZero: 1 }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.madnessSaves?.failures).toBe(2);
+    expect(result.health.currentMentalHealth).toBe(0);
+  });
+
+  it("allows death-roll box edits while deranged", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        currentMentalHealth: 0,
+        status: "DERANGED",
+        madnessSaves: { successes: 0, failures: 3 },
+      }),
+      { deathSaves: { successes: 1, failures: 0 } }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.status).toBe("DERANGED");
+    expect(result.health.deathSaves).toEqual({ successes: 1, failures: 0 });
+  });
+
+  it("keeps ALIVE when only status is patched while failures are already 3", () => {
+    const result = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        status: "DECEASED",
+        deathSaves: { successes: 0, failures: 3 },
+      }),
+      { status: "ALIVE" }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.health.status).toBe("ALIVE");
+    expect(result.health.deathSaves.failures).toBe(3);
+  });
+
+  it("sets DERANGED on three madness failures unless already DECEASED", () => {
+    const deranged = applyCharacterHealthPatch(
+      health({ currentMentalHealth: 0 }),
+      { madnessSaves: { successes: 0, failures: 3 } }
+    );
+    expect(deranged.ok).toBe(true);
+    if (deranged.ok) expect(deranged.health.status).toBe("DERANGED");
+
+    const deceased = applyCharacterHealthPatch(
+      health({
+        currentPhysicalHealth: 0,
+        currentMentalHealth: 0,
+        status: "DECEASED",
+        deathSaves: { successes: 0, failures: 3 },
+      }),
+      { madnessSaves: { successes: 0, failures: 3 } }
+    );
+    expect(deceased.ok).toBe(false);
+  });
+});

--- a/test/app/lib/crisisRoll.test.ts
+++ b/test/app/lib/crisisRoll.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  crisisPoolIsSuccess,
+  deathRollDicePoolSize,
+  madnessRollDicePoolSize,
+} from "@/app/lib/crisisRoll";
+
+describe("deathRollDicePoolSize", () => {
+  it("uses the higher of Resilience and Stamina, minus injuries, minimum 1", () => {
+    expect(deathRollDicePoolSize(3, 5, 0)).toBe(5);
+    expect(deathRollDicePoolSize(4, 2, 1)).toBe(3);
+    expect(deathRollDicePoolSize(2, 2, 3)).toBe(1);
+  });
+});
+
+describe("madnessRollDicePoolSize", () => {
+  it("uses Mentality minus trauma, minimum 1", () => {
+    expect(madnessRollDicePoolSize(4, 1)).toBe(3);
+    expect(madnessRollDicePoolSize(2, 3)).toBe(1);
+  });
+});
+
+describe("crisisPoolIsSuccess", () => {
+  it("succeeds when any die is 8, 9, or 10", () => {
+    expect(crisisPoolIsSuccess([1, 8, 3])).toBe(true);
+    expect(crisisPoolIsSuccess([10])).toBe(true);
+    expect(crisisPoolIsSuccess([7, 7, 2])).toBe(false);
+    expect(crisisPoolIsSuccess([])).toBe(false);
+  });
+});


### PR DESCRIPTION
Make the character sheet playable for inventory, vehicles, and crisis rolls.

Keep stack quantity and nicknames, death/madness tracks with Status, and Update/Level-up from wiping in-play HP, paths, and favourite weapons.